### PR TITLE
refactor: use session context for Claude calls

### DIFF
--- a/handlers/messages.go
+++ b/handlers/messages.go
@@ -114,7 +114,7 @@ func (mh *MessageHandler) handleStartConversation(msg models.BaseMessage, socket
 	}
 
 	// Auto-commit changes if needed
-	commitResult, err := mh.gitUseCase.AutoCommitChangesIfNeeded(payload.MessageLink)
+	commitResult, err := mh.gitUseCase.AutoCommitChangesIfNeeded(payload.MessageLink, claudeResult.SessionID)
 	if err != nil {
 		log.Info("❌ Auto-commit failed: %v", err)
 		return fmt.Errorf("auto-commit failed: %w", err)
@@ -233,7 +233,7 @@ func (mh *MessageHandler) handleUserMessage(msg models.BaseMessage, socketClient
 	}
 
 	// Auto-commit changes if needed
-	commitResult, err := mh.gitUseCase.AutoCommitChangesIfNeeded(payload.MessageLink)
+	commitResult, err := mh.gitUseCase.AutoCommitChangesIfNeeded(payload.MessageLink, claudeResult.SessionID)
 	if err != nil {
 		log.Info("❌ Auto-commit failed: %v", err)
 		return fmt.Errorf("auto-commit failed: %w", err)


### PR DESCRIPTION
## Summary
- Refactored Claude API calls to use session context instead of creating new conversations for git operations
- Updated commit message generation and PR creation/update flows to reuse existing Claude sessions

## Why
This change improves efficiency and maintains conversation context when performing automated git operations like generating commit messages and PR descriptions, ensuring consistency within a single ccagent session.

---
Generated by [Claude Control](https://claudecontrol.com) from this [slack thread](https://pres-ltd.slack.com/archives/C096LGC5PBN/p1755015621513999?thread_ts=1755015621.513999&cid=C096LGC5PBN)