### PR TITLE
bugfix: reload git remote repo on env reload

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -80,14 +80,21 @@ func NewCmdRunner(agentType, permissionMode, cursorModel string) (*CmdRunner, er
 	agentID := core.NewID("ccaid")
 	log.Info("🆔 Using persistent agent ID: %s", agentID)
 
-	log.Info("📋 Completed successfully - initialized CmdRunner with %s agent", agentType)
-	return &CmdRunner{
+	// Create the CmdRunner instance
+	cr := &CmdRunner{
 		messageHandler: messageHandler,
 		gitUseCase:     gitUseCase,
 		envManager:     envManager,
 		agentID:        agentID,
 		reconnectChan:  make(chan struct{}, 1),
-	}, nil
+	}
+
+	// Register GitHub token update hook
+	envManager.RegisterReloadHook(gitUseCase.GithubTokenUpdateHook)
+	log.Info("📎 Registered GitHub token update hook")
+
+	log.Info("📋 Completed successfully - initialized CmdRunner with %s agent", agentType)
+	return cr, nil
 }
 
 // createCLIAgent creates the appropriate CLI agent based on the agent type

--- a/usecases/git.go
+++ b/usecases/git.go
@@ -2,6 +2,7 @@ package usecases
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -44,6 +45,24 @@ func NewGitUseCase(
 		claudeService: claudeService,
 		appState:      appState,
 	}
+}
+
+func (g *GitUseCase) GithubTokenUpdateHook() {
+	// Get the GitHub token from environment
+	ghToken := os.Getenv("GH_TOKEN")
+	if ghToken == "" {
+		log.Debug("No GH_TOKEN environment variable found, skipping remote URL update")
+		return
+	}
+
+	log.Info("🔄 GH_TOKEN detected, updating Git remote URL with token")
+	if err := g.gitClient.UpdateRemoteURLWithToken(ghToken); err != nil {
+		log.Error("Failed to update Git remote URL with token: %v", err)
+		// Don't fail the entire reload process, just log the error
+		return
+	}
+
+	log.Info("✅ Successfully updated Git remote URL with refreshed token")
 }
 
 func (g *GitUseCase) ValidateGitEnvironment() error {


### PR DESCRIPTION
The `GH_TOKEN` env variable we use in containerised environments only applies when using the `gh` command. 

However, with `git`, you need to pass it by setting the remote origin of the repo.

To do this, we will invoke a hook anytime the env is updated to also update the remote URL we are dealing with for the ccagent.