### PR TITLE
Fix repository identifier extraction for x-access-token URLs

### DIFF
--- a/clients/git.go
+++ b/clients/git.go
@@ -527,6 +527,16 @@ func (g *GitClient) GetRepositoryIdentifier() (string, error) {
 
 	// Remove https:// prefix
 	repoIdentifier := strings.TrimPrefix(remoteURL, "https://")
+
+	// Strip x-access-token authentication if present (e.g., "x-access-token:ghs_...@github.com/owner/repo")
+	if strings.Contains(repoIdentifier, "@") {
+		parts := strings.Split(repoIdentifier, "@")
+		if len(parts) >= 2 {
+			// Take everything after the last @ symbol (handles multiple @ symbols)
+			repoIdentifier = parts[len(parts)-1]
+		}
+	}
+
 	log.Info("✅ Repository identifier: %s", repoIdentifier)
 	log.Info("📋 Completed successfully - got repository identifier")
 	return repoIdentifier, nil


### PR DESCRIPTION
## Why?

In production environments, ccagent uses x-access-token authentication for Git remote URLs. The current repository identifier extraction doesn't handle this format, resulting in headers like:

```
X-CCAGENT-REPO: x-access-token:ghs_...@github.com/owner/repo
```

Instead of the expected:

```
X-CCAGENT-REPO: github.com/owner/repo
```

## Summary

Updated `GetRepositoryIdentifier()` method to strip authentication tokens from repository URLs when determining the repository identifier for the `X-CCAGENT-REPO` header.

### Changes Made

- **Enhanced URL parsing** in `clients/git.go`
  - Strips x-access-token and other authentication from URLs
  - Handles multiple @ symbols by taking content after the last one
  - Maintains backward compatibility with standard HTTPS URLs

This ensures the Claude Control platform receives clean repository identifiers regardless of authentication method.