### PR TITLE
fix: rename bypass permissions flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ ccagent [OPTIONS]
 
 Options:
   --agent=[claude|cursor]              AI assistant to use (default: claude)
-  --claude-bypass-permissions          Use bypassPermissions for Claude (sandbox only)
+  --bypass-permissions                 Use bypassPermissions for Claude (sandbox only)
   --cursor-model=[gpt-5|sonnet-4|sonnet-4-thinking]  Model for Cursor agent
   -v, --version                        Show version information
   -h, --help                           Show help message
@@ -110,7 +110,7 @@ Options:
 ccagent --agent claude
 
 # Bypass permissions (Recommended in a secure sandbox environment only)
-ccagent --agent claude --claude-bypass-permissions
+ccagent --agent claude --bypass-permissions
 ```
 
 #### Cursor Agent
@@ -163,7 +163,7 @@ ccagent operates in different permission modes depending on the AI assistant and
 - **Best Practice**: Use this mode when running ccagent on your local development machine
 
 ### Bypass Permissions Mode
-- **Claude Code with `--claude-bypass-permissions`**: Allows unrestricted system access
+- **Claude Code with `--bypass-permissions`**: Allows unrestricted system access
 - **Cursor Agent**: **Always runs in bypass mode by default**
 
 When running in bypass permissions mode, **anyone with access to your Slack workspace or Discord server can execute arbitrary commands on your system with your user privileges**. It's recommended that you use this mode only if you're running the agent in a secure environment like a docker container or a remote, isolated server.
@@ -179,4 +179,3 @@ MIT License - see [LICENSE](LICENSE) file for details.
 ## Support
 
 Contact us at support@claudecontrol.com
-

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -199,7 +199,7 @@ func createCLIAgent(
 type Options struct {
 	//nolint
 	Agent             string `long:"agent" description:"CLI agent to use (claude or cursor)" choice:"claude" choice:"cursor" default:"claude"`
-	BypassPermissions bool   `long:"claude-bypass-permissions" description:"Use bypassPermissions mode for Claude (only applies when --agent=claude) (WARNING: Only use in controlled sandbox environments)"`
+	BypassPermissions bool   `long:"bypass-permissions" description:"Use bypassPermissions mode for Claude (only applies when --agent=claude) (WARNING: Only use in controlled sandbox environments)"`
 	CursorModel       string `long:"cursor-model" description:"Model to use with Cursor agent (only applies when --agent=cursor)" choice:"gpt-5" choice:"sonnet-4" choice:"sonnet-4-thinking"`
 	Version           bool   `long:"version" short:"v" description:"Show version information"`
 }
@@ -267,7 +267,7 @@ func main() {
 		permissionMode = "bypassPermissions"
 		fmt.Fprintf(
 			os.Stderr,
-			"Warning: --claude-bypass-permissions flag should only be used in a controlled, sandbox environment. Otherwise, anyone from Slack will have access to your entire system\n",
+			"Warning: --bypass-permissions flag should only be used in a controlled, sandbox environment. Otherwise, anyone from Slack will have access to your entire system\n",
 		)
 	}
 


### PR DESCRIPTION
## Summary
- Rename CLI flag and documentation references to `--bypass-permissions`
- Update warning text to reflect new flag name

## Why
- Align flag naming with desired terminology
- Ensure users see accurate instructions and warnings

---
Generated by [Claude Control](https://claudecontrol.com) from this [slack thread](https://pres-ltd.slack.com/archives/C09JJSHLT4M/p1762597253815249?thread_ts=1762597253.815249&cid=C09JJSHLT4M)