### PR TITLE
fix: handle OpenCode structured error messages

### DIFF
--- a/services/opencode/opencode_messages.go
+++ b/services/opencode/opencode_messages.go
@@ -93,6 +93,28 @@ func (t OpenCodeToolUseMessage) GetSessionID() string {
 	return t.SessionID
 }
 
+// OpenCodeErrorMessage represents a structured JSON error message from OpenCode
+// This happens when opencode encounters an error during execution (e.g. invalid model,
+// provider errors) and emits a {"type":"error",...} JSON line.
+type OpenCodeErrorMessage struct {
+	Type      string `json:"type"`
+	SessionID string `json:"sessionID"`
+	Error     struct {
+		Name string `json:"name"`
+		Data struct {
+			Message string `json:"message"`
+		} `json:"data"`
+	} `json:"error"`
+}
+
+func (e OpenCodeErrorMessage) GetType() string {
+	return e.Type
+}
+
+func (e OpenCodeErrorMessage) GetSessionID() string {
+	return e.SessionID
+}
+
 // OpenCodeRawErrorMessage represents a non-JSON error output from OpenCode
 // This happens when opencode itself crashes or encounters a startup error
 type OpenCodeRawErrorMessage struct {
@@ -188,6 +210,12 @@ func parseOpenCodeMessage(lineBytes []byte) OpenCodeMessage {
 		if err := json.Unmarshal(lineBytes, &toolMsg); err == nil {
 			return toolMsg
 		}
+
+	case "error":
+		var errMsg OpenCodeErrorMessage
+		if err := json.Unmarshal(lineBytes, &errMsg); err == nil {
+			return errMsg
+		}
 	}
 
 	// For all other types, extract basic info for unknown message
@@ -224,10 +252,21 @@ func ExtractOpenCodeSessionID(messages []OpenCodeMessage) string {
 
 // ExtractOpenCodeResult extracts the result text from OpenCode messages
 func ExtractOpenCodeResult(messages []OpenCodeMessage) (string, error) {
-	// Check for raw error messages first - these indicate opencode crashed or failed to start
+	// Check for error messages first - these indicate opencode encountered a runtime error
 	for _, msg := range messages {
+		if errMsg, ok := msg.(OpenCodeErrorMessage); ok {
+			// Structured JSON error from opencode (e.g. model not found, provider errors)
+			errorDetail := errMsg.Error.Data.Message
+			if errorDetail == "" {
+				errorDetail = errMsg.Error.Name
+			}
+			if errorDetail == "" {
+				errorDetail = "unknown error"
+			}
+			return "", fmt.Errorf("opencode error: %s", errorDetail)
+		}
 		if rawErr, ok := msg.(OpenCodeRawErrorMessage); ok {
-			// Extract a meaningful error message from the raw output
+			// Non-JSON error output (opencode crashed or failed to start)
 			errorSummary := extractErrorSummary(rawErr.RawOutput)
 			return "", fmt.Errorf("opencode error: %s", errorSummary)
 		}

--- a/services/opencode/opencode_messages_test.go
+++ b/services/opencode/opencode_messages_test.go
@@ -55,6 +55,24 @@ func TestMapOpenCodeOutputToMessages(t *testing.T) {
 			expectError:   false,
 		},
 		{
+			name:          "error message type parsed as error",
+			input:         `{"type":"error","timestamp":1773826143793,"sessionID":"ses_err123","error":{"name":"UnknownError","data":{"message":"Model not found: opencode/minimax-m2.1."}}}`,
+			expectedCount: 1,
+			expectedTypes: []string{"error"},
+			expectError:   false,
+		},
+		{
+			name: "JS stack trace followed by error JSON line",
+			input: `1182 |     const info = provider.models[modelID]
+1187 |       throw new ModelNotFoundError({ providerID, modelID, suggestions })
+                   ^
+ProviderModelNotFoundError: ProviderModelNotFoundError
+{"type":"error","timestamp":1773826143793,"sessionID":"ses_err456","error":{"name":"UnknownError","data":{"message":"Model not found: opencode/minimax-m2.1."}}}`,
+			expectedCount: 1,
+			expectedTypes: []string{"error"},
+			expectError:   false,
+		},
+		{
 			name:          "raw error output detected as raw_error type",
 			input:         `not json at all`,
 			expectedCount: 1,
@@ -148,6 +166,11 @@ func TestExtractOpenCodeSessionID(t *testing.T) {
 			expectedID: "ses_fromtext",
 		},
 		{
+			name:       "extracts session ID from error message",
+			input:      `{"type":"error","timestamp":1773826143793,"sessionID":"ses_fromerror","error":{"name":"UnknownError","data":{"message":"Model not found."}}}`,
+			expectedID: "ses_fromerror",
+		},
+		{
 			name: "extracts session ID when non-JSON preamble precedes JSON output",
 			input: `Performing one time database migration, may take a few minutes...
 {"type":"step_start","timestamp":1759406013703,"sessionID":"ses_aftermigration","part":{}}
@@ -205,6 +228,29 @@ func TestExtractOpenCodeResult(t *testing.T) {
 {"type":"step_finish","timestamp":1759406016100,"sessionID":"ses_123","part":{}}`,
 			expectedResult: "Let me query the database.\n\nLet me check the tables.\n\nThere are 166 registered users.",
 			expectError:    false,
+		},
+		{
+			name:           "returns opencode error for structured error message",
+			input:          `{"type":"error","timestamp":1773826143793,"sessionID":"ses_err123","error":{"name":"UnknownError","data":{"message":"Model not found: opencode/minimax-m2.1."}}}`,
+			expectedResult: "",
+			expectError:    true,
+			errorContains:  "opencode error: Model not found: opencode/minimax-m2.1.",
+		},
+		{
+			name:           "returns opencode error with name fallback when no message",
+			input:          `{"type":"error","timestamp":1773826143793,"sessionID":"ses_err123","error":{"name":"ProviderModelNotFoundError","data":{}}}`,
+			expectedResult: "",
+			expectError:    true,
+			errorContains:  "opencode error: ProviderModelNotFoundError",
+		},
+		{
+			name: "returns opencode error from JS stack trace + error JSON",
+			input: `1182 |     const info = provider.models[modelID]
+ProviderModelNotFoundError: ProviderModelNotFoundError
+{"type":"error","timestamp":1773826143793,"sessionID":"ses_err456","error":{"name":"UnknownError","data":{"message":"Model not found: opencode/minimax-m2.1."}}}`,
+			expectedResult: "",
+			expectError:    true,
+			errorContains:  "opencode error: Model not found: opencode/minimax-m2.1.",
 		},
 		{
 			name:           "returns error when no text messages",


### PR DESCRIPTION
## Summary
- Adds `OpenCodeErrorMessage` type to handle `{"type":"error",...}` JSON messages from OpenCode CLI
- Updates `parseOpenCodeMessage` to parse the `error` type into a structured message instead of `UnknownOpenCodeMessage`
- Updates `ExtractOpenCodeResult` to surface the error message from structured error messages (with fallback to error name)
- Previously, OpenCode runtime errors (e.g. invalid model, provider failures) were silently swallowed and reported as the generic "no text message found"

## Test plan
- [x] Added test cases for parsing `error` type messages in `TestMapOpenCodeOutputToMessages`
- [x] Added test cases for extracting error details in `TestExtractOpenCodeResult` (message field, name fallback, JS stack trace + error JSON)
- [x] Added test for session ID extraction from error messages
- [x] All 30 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)