### PR TITLE
Fix: surface OpenCode API errors in error messages

### DIFF
--- a/services/opencode/opencode_messages.go
+++ b/services/opencode/opencode_messages.go
@@ -93,6 +93,29 @@ func (t OpenCodeToolUseMessage) GetSessionID() string {
 	return t.SessionID
 }
 
+// OpenCodeErrorMessage represents a JSON error message from OpenCode (type: "error")
+// This happens when OpenCode encounters an API error (e.g. invalid API key, insufficient balance,
+// model not found) and emits a structured error JSON line.
+type OpenCodeErrorMessage struct {
+	Type      string `json:"type"`
+	SessionID string `json:"sessionID"`
+	Error     struct {
+		Name string `json:"name"`
+		Data struct {
+			Message    string `json:"message"`
+			StatusCode int    `json:"statusCode"`
+		} `json:"data"`
+	} `json:"error"`
+}
+
+func (e OpenCodeErrorMessage) GetType() string {
+	return e.Type
+}
+
+func (e OpenCodeErrorMessage) GetSessionID() string {
+	return e.SessionID
+}
+
 // OpenCodeRawErrorMessage represents a non-JSON error output from OpenCode
 // This happens when opencode itself crashes or encounters a startup error
 type OpenCodeRawErrorMessage struct {
@@ -188,6 +211,12 @@ func parseOpenCodeMessage(lineBytes []byte) OpenCodeMessage {
 		if err := json.Unmarshal(lineBytes, &toolMsg); err == nil {
 			return toolMsg
 		}
+
+	case "error":
+		var errMsg OpenCodeErrorMessage
+		if err := json.Unmarshal(lineBytes, &errMsg); err == nil {
+			return errMsg
+		}
 	}
 
 	// For all other types, extract basic info for unknown message
@@ -224,10 +253,21 @@ func ExtractOpenCodeSessionID(messages []OpenCodeMessage) string {
 
 // ExtractOpenCodeResult extracts the result text from OpenCode messages
 func ExtractOpenCodeResult(messages []OpenCodeMessage) (string, error) {
-	// Check for raw error messages first - these indicate opencode crashed or failed to start
+	// Check for error messages first
 	for _, msg := range messages {
+		// JSON error messages (type: "error") — API errors like invalid key, insufficient balance
+		if errMsg, ok := msg.(OpenCodeErrorMessage); ok {
+			errorDetail := errMsg.Error.Data.Message
+			if errorDetail == "" {
+				errorDetail = errMsg.Error.Name
+			}
+			if errorDetail == "" {
+				errorDetail = "unknown error"
+			}
+			return "", fmt.Errorf("opencode API error: %s", errorDetail)
+		}
+		// Raw error messages — opencode crashed or failed to start (non-JSON output)
 		if rawErr, ok := msg.(OpenCodeRawErrorMessage); ok {
-			// Extract a meaningful error message from the raw output
 			errorSummary := extractErrorSummary(rawErr.RawOutput)
 			return "", fmt.Errorf("opencode error: %s", errorSummary)
 		}

--- a/services/opencode/opencode_messages_test.go
+++ b/services/opencode/opencode_messages_test.go
@@ -94,6 +94,23 @@ Migration complete.
 			expectedTypes: []string{"text"},
 			expectError:   false,
 		},
+		{
+			name:          "error message type parsed as error",
+			input:         `{"type":"error","timestamp":1774182448331,"sessionID":"ses_abc","error":{"name":"APIError","data":{"message":"Invalid API key.","statusCode":401}}}`,
+			expectedCount: 1,
+			expectedTypes: []string{"error"},
+			expectError:   false,
+		},
+		{
+			name: "preamble text followed by error JSON",
+			input: `Performing one time database migration, may take a few minutes...
+sqlite-migration:done
+Database migration complete.
+{"type":"error","timestamp":1774182448331,"sessionID":"ses_abc","error":{"name":"APIError","data":{"message":"Insufficient balance.","statusCode":401}}}`,
+			expectedCount: 1,
+			expectedTypes: []string{"error"},
+			expectError:   false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -153,6 +170,11 @@ func TestExtractOpenCodeSessionID(t *testing.T) {
 {"type":"step_start","timestamp":1759406013703,"sessionID":"ses_aftermigration","part":{}}
 {"type":"text","timestamp":1759406015783,"sessionID":"ses_aftermigration","part":{"type":"text","text":"Hello"}}`,
 			expectedID: "ses_aftermigration",
+		},
+		{
+			name:       "extracts session ID from error message",
+			input:      `{"type":"error","timestamp":1774182448331,"sessionID":"ses_errsession","error":{"name":"APIError","data":{"message":"Invalid API key.","statusCode":401}}}`,
+			expectedID: "ses_errsession",
 		},
 	}
 
@@ -254,6 +276,51 @@ RipgrepExtractionFailedError: RipgrepExtractionFailedError
 			expectedResult: "Hello! Migration is done.",
 			expectError:    false,
 		},
+		{
+			name:           "returns API error for invalid API key",
+			input:          `{"type":"error","timestamp":1774182448331,"sessionID":"ses_abc","error":{"name":"APIError","data":{"message":"Invalid API key.","statusCode":401}}}`,
+			expectedResult: "",
+			expectError:    true,
+			errorContains:  "opencode API error: Invalid API key.",
+		},
+		{
+			name:           "returns API error for insufficient balance",
+			input:          `{"type":"error","timestamp":1774182949655,"sessionID":"ses_def","error":{"name":"APIError","data":{"message":"Insufficient balance. Manage your billing here: https://opencode.ai/workspace/billing","statusCode":401}}}`,
+			expectedResult: "",
+			expectError:    true,
+			errorContains:  "opencode API error: Insufficient balance.",
+		},
+		{
+			name:           "returns API error for model not found",
+			input:          `{"type":"error","timestamp":1774182448331,"sessionID":"ses_ghi","error":{"name":"UnknownError","data":{"message":"Model not found: opencode/claude-sonnet-4-6."}}}`,
+			expectedResult: "",
+			expectError:    true,
+			errorContains:  "opencode API error: Model not found: opencode/claude-sonnet-4-6.",
+		},
+		{
+			name: "returns API error when preamble precedes error JSON",
+			input: `Performing one time database migration, may take a few minutes...
+sqlite-migration:done
+Database migration complete.
+{"type":"error","timestamp":1774182448331,"sessionID":"ses_jkl","error":{"name":"APIError","data":{"message":"Invalid API key.","statusCode":401}}}`,
+			expectedResult: "",
+			expectError:    true,
+			errorContains:  "opencode API error: Invalid API key.",
+		},
+		{
+			name:           "returns API error with error name when message is empty",
+			input:          `{"type":"error","timestamp":1774182448331,"sessionID":"ses_mno","error":{"name":"NetworkError","data":{}}}`,
+			expectedResult: "",
+			expectError:    true,
+			errorContains:  "opencode API error: NetworkError",
+		},
+		{
+			name:           "returns unknown error when both name and message are empty",
+			input:          `{"type":"error","timestamp":1774182448331,"sessionID":"ses_pqr","error":{}}`,
+			expectedResult: "",
+			expectError:    true,
+			errorContains:  "opencode API error: unknown error",
+		},
 	}
 
 	for _, tt := range tests {
@@ -301,6 +368,26 @@ func TestOpenCodeTextMessage_GetSessionID(t *testing.T) {
 	}
 	if msg.GetSessionID() != "ses_123" {
 		t.Errorf("Expected session ID 'ses_123', got %q", msg.GetSessionID())
+	}
+}
+
+func TestOpenCodeErrorMessage_GetType(t *testing.T) {
+	msg := OpenCodeErrorMessage{
+		Type:      "error",
+		SessionID: "ses_err123",
+	}
+	if msg.GetType() != "error" {
+		t.Errorf("Expected type 'error', got %q", msg.GetType())
+	}
+}
+
+func TestOpenCodeErrorMessage_GetSessionID(t *testing.T) {
+	msg := OpenCodeErrorMessage{
+		Type:      "error",
+		SessionID: "ses_err123",
+	}
+	if msg.GetSessionID() != "ses_err123" {
+		t.Errorf("Expected session ID 'ses_err123', got %q", msg.GetSessionID())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `OpenCodeErrorMessage` type to handle OpenCode's `"type":"error"` JSON messages
- Parse structured error responses (API key invalid, insufficient balance, model not found) and surface the actual error message
- Previously these errors were silently swallowed and reported as generic "no text message found"

## Context
The `claude-rc` agent was failing repeatedly with `failed to extract OpenCode result: no text message found`. Investigation revealed OpenCode was returning a structured JSON error (`{"type":"error",...,"message":"Insufficient balance."}`) but nairid mapped `"error"` type to `UnknownOpenCodeMessage`, losing the actual error context.

With this fix, the error will now surface as: `opencode API error: Insufficient balance.`

## Test plan
- [x] All existing OpenCode message parsing tests pass
- [x] New tests for: invalid API key, insufficient balance, model not found, error with preamble, empty error name/message fallbacks
- [x] `go test ./services/opencode/ -v` passes (all 41 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)