### PR TITLE
fix: namespace worktrees, state, and logs per agent ID (#201)

### DIFF
--- a/cmd/agent_id_test.go
+++ b/cmd/agent_id_test.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeAgentIDFromRepoIdentifier(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "github https URL",
+			in:   "github.com/owner/repo",
+			want: "github.com-owner-repo",
+		},
+		{
+			name: "gitlab nested groups",
+			in:   "gitlab.com/group/subgroup/repo",
+			want: "gitlab.com-group-subgroup-repo",
+		},
+		{
+			name: "windows-style backslashes",
+			in:   `host\owner\repo`,
+			want: "host-owner-repo",
+		},
+		{
+			name: "no separators",
+			in:   "single-token",
+			want: "single-token",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeAgentIDFromRepoIdentifier(tt.in)
+			if got != tt.want {
+				t.Errorf("sanitizeAgentIDFromRepoIdentifier(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// initGitRepoWithRemote creates a temp git repo with the given HTTPS remote URL
+// and returns its path. Skips the test if `git` isn't available.
+func initGitRepoWithRemote(t *testing.T, remoteURL string) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skipf("git not available: %v", err)
+	}
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q", "-b", "main"},
+		{"remote", "add", "origin", remoteURL},
+		// Some git versions need a HEAD before they'll cooperate.
+		{"-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-q", "-m", "init"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+	return dir
+}
+
+func clearAgentIDEnv(t *testing.T) {
+	t.Helper()
+	saved := map[string]string{}
+	for _, k := range []string{"NAIRI_AGENT_ID", "EKSEC_AGENT_ID"} {
+		saved[k] = os.Getenv(k)
+		_ = os.Unsetenv(k)
+	}
+	t.Cleanup(func() {
+		for k, v := range saved {
+			if v == "" {
+				_ = os.Unsetenv(k)
+			} else {
+				_ = os.Setenv(k, v)
+			}
+		}
+	})
+}
+
+func TestResolveNairiAgentIDForStartup_PrefersEnvVar(t *testing.T) {
+	clearAgentIDEnv(t)
+	_ = os.Setenv("NAIRI_AGENT_ID", "explicit-id")
+	t.Cleanup(func() { _ = os.Unsetenv("NAIRI_AGENT_ID") })
+
+	got, err := resolveNairiAgentIDForStartup("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "explicit-id" {
+		t.Errorf("expected explicit env var to win, got %q", got)
+	}
+}
+
+func TestResolveNairiAgentIDForStartup_FallsBackToRepoIdentifier(t *testing.T) {
+	clearAgentIDEnv(t)
+	repoDir := initGitRepoWithRemote(t, "https://github.com/example-org/example-repo")
+
+	got, err := resolveNairiAgentIDForStartup(repoDir)
+	if err != nil {
+		t.Fatalf("expected repo-derived ID, got error: %v", err)
+	}
+	want := "github.com-example-org-example-repo"
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+func TestResolveNairiAgentIDForStartup_DistinctReposGetDistinctIDs(t *testing.T) {
+	clearAgentIDEnv(t)
+	repoA := initGitRepoWithRemote(t, "https://github.com/org/repo-a")
+	repoB := initGitRepoWithRemote(t, "https://github.com/org/repo-b")
+
+	idA, err := resolveNairiAgentIDForStartup(repoA)
+	if err != nil {
+		t.Fatalf("repoA resolution: %v", err)
+	}
+	idB, err := resolveNairiAgentIDForStartup(repoB)
+	if err != nil {
+		t.Fatalf("repoB resolution: %v", err)
+	}
+	if idA == idB {
+		t.Errorf("expected distinct IDs for distinct repos, got %q for both", idA)
+	}
+	// Concrete property #201 cares about: the namespacing key differs, so
+	// ~/.eksec_worktrees/agent-{idA}/ and ~/.eksec_worktrees/agent-{idB}/ are
+	// disjoint subtrees and the three reclaim/cleanup scans can't cross over.
+	if strings.HasPrefix(idA, idB) || strings.HasPrefix(idB, idA) {
+		t.Errorf("agent IDs must not be prefixes of each other: %q vs %q", idA, idB)
+	}
+}
+
+func TestResolveNairiAgentIDForStartup_NoRepoNoEnvErrors(t *testing.T) {
+	clearAgentIDEnv(t)
+	// Pass a non-git directory as the repo flag — resolveRepositoryContext will
+	// treat the explicit path as IsRepoMode=true, but git will fail to find a
+	// remote, so we should still get an error pointing at NAIRI_AGENT_ID.
+	nonGitDir := t.TempDir()
+
+	_, err := resolveNairiAgentIDForStartup(nonGitDir)
+	if err == nil {
+		t.Fatal("expected error when NAIRI_AGENT_ID is unset and dir is not a git repo")
+	}
+	if !strings.Contains(err.Error(), "NAIRI_AGENT_ID") {
+		t.Errorf("expected error to mention NAIRI_AGENT_ID, got: %v", err)
+	}
+}
+
+// TestResolveNairiAgentIDForStartup_RepoIDIsFilesystemSafe verifies the value
+// returned by the resolver can be safely used as a directory component.
+func TestResolveNairiAgentIDForStartup_RepoIDIsFilesystemSafe(t *testing.T) {
+	clearAgentIDEnv(t)
+	repoDir := initGitRepoWithRemote(t, "https://github.com/example-org/example-repo")
+
+	id, err := resolveNairiAgentIDForStartup(repoDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.ContainsAny(id, `/\`) {
+		t.Errorf("resolved agent ID must not contain path separators, got %q", id)
+	}
+	// Round-trip: it should also be usable as a filename.
+	probe := filepath.Join(t.TempDir(), "agent-"+id)
+	if err := os.MkdirAll(probe, 0755); err != nil {
+		t.Errorf("could not create dir with sanitized agent ID as a path component: %v", err)
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -45,12 +45,14 @@ type CmdRunner struct {
 	appState        *models.AppState
 	rotatingWriter  *log.RotatingWriter
 	envManager      *env.EnvManager
-	agentID         string
+	agentID         string // locally-generated ccaid_* used for X-CCAGENT-ID header
+	nairiAgentID    string // user-supplied NAIRI_AGENT_ID used for X-AGENT-ID and per-instance namespacing
 	agentsApiClient *clients.AgentsApiClient
 	wsURL           string
 	nairiAPIKey     string
 	dirLock         *utils.DirLock
 	repoLock        *utils.DirLock
+	agentLock       *utils.DirLock
 
 	// Persistent worker pools reused across reconnects
 	blockingWorkerPool *workerpool.WorkerPool
@@ -355,6 +357,58 @@ func processPermissions(agentType, workDir, targetHomeDir string) error {
 	return nil
 }
 
+// resolveNairiAgentIDForStartup resolves the agent ID that namespaces this
+// instance's worktrees, state, and logs (issue #201). It runs at process start,
+// before any of those paths are touched.
+//
+// Resolution order:
+//  1. NAIRI_AGENT_ID (or legacy EKSEC_AGENT_ID) env var — explicit takes
+//     precedence so users can override the derived value.
+//  2. Repo mode without env var: derived from the git remote URL (e.g.
+//     "github.com/owner/repo") with path-unsafe characters replaced. This
+//     preserves backwards compatibility for self-hosted users upgrading nairid
+//     without changing their env vars — same fallback the legacy code used.
+//  3. No-repo mode without env var: error (NAIRI_AGENT_ID was already required
+//     in no-repo mode prior to this change).
+//
+// Two instances on different repos resolve to different IDs and don't collide.
+// Two instances on the same repo resolve to the same ID; the agent lock catches
+// the duplicate and fails loudly.
+func resolveNairiAgentIDForStartup(repoFlag string) (string, error) {
+	if id, err := env.GetAgentID(); err == nil {
+		return id, nil
+	}
+
+	gitClient := clients.NewGitClient()
+	repoCtx, err := resolveRepositoryContext(repoFlag, gitClient)
+	if err != nil {
+		return "", fmt.Errorf("NAIRI_AGENT_ID is not set and repository context could not be resolved: %w", err)
+	}
+	if !repoCtx.IsRepoMode {
+		return "", fmt.Errorf("NAIRI_AGENT_ID environment variable is required in no-repo mode")
+	}
+
+	gitClient.SetRepoPathProvider(func() string { return repoCtx.RepoPath })
+	repoIdent, err := gitClient.GetRepositoryIdentifier()
+	if err != nil {
+		return "", fmt.Errorf("NAIRI_AGENT_ID is not set and repository identifier could not be derived (set NAIRI_AGENT_ID explicitly): %w", err)
+	}
+
+	derivedID := sanitizeAgentIDFromRepoIdentifier(repoIdent)
+	log.Info("📋 NAIRI_AGENT_ID not set; using repo-derived agent ID: %s (from %s)", derivedID, repoIdent)
+	return derivedID, nil
+}
+
+// sanitizeAgentIDFromRepoIdentifier converts a repo identifier (e.g.
+// "github.com/owner/repo") into a filesystem-safe agent ID by replacing path
+// separators with dashes. The agent ID becomes a directory component
+// (~/.eksec_worktrees/agent-{id}/) so slashes would create unintended subdirs.
+func sanitizeAgentIDFromRepoIdentifier(repoIdent string) string {
+	safe := strings.ReplaceAll(repoIdent, "/", "-")
+	safe = strings.ReplaceAll(safe, "\\", "-")
+	return safe
+}
+
 // resolveRepositoryContext determines the repository mode and path based on the --repo flag
 // and current working directory. Returns a RepositoryContext indicating:
 // - Repo mode with explicit path (--repo flag provided)
@@ -410,7 +464,11 @@ func resolveAutoDetectedRepoContext(gitClient *clients.GitClient) (*models.Repos
 	}, nil
 }
 
-func NewCmdRunner(agentType, permissionMode, model, repoPath string) (*CmdRunner, error) {
+func NewCmdRunner(
+	envManager *env.EnvManager,
+	nairiAgentID string,
+	agentType, permissionMode, model, repoPath string,
+) (*CmdRunner, error) {
 	log.Info("📋 Starting to initialize CmdRunner with agent: %s", agentType)
 
 	// Validate model compatibility with agent
@@ -418,21 +476,11 @@ func NewCmdRunner(agentType, permissionMode, model, repoPath string) (*CmdRunner
 		return nil, err
 	}
 
-	// Create log directory for agent service
-	configDir, err := env.GetConfigDir()
+	// Per-agent log directory for CLI agent session logs
+	logDir, err := env.GetAgentLogsDir(nairiAgentID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get config directory: %w", err)
+		return nil, fmt.Errorf("failed to get agent logs directory: %w", err)
 	}
-	logDir := filepath.Join(configDir, "logs")
-
-	// Initialize environment manager first
-	envManager, err := env.NewEnvManager()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create environment manager: %w", err)
-	}
-
-	// Start periodic refresh every 1 minute
-	envManager.StartPeriodicRefresh(1 * time.Minute)
 
 	// Get API key and WS URL for agents API client
 	// Support legacy EKSEC_* env vars for backwards compatibility
@@ -454,12 +502,7 @@ func NewCmdRunner(agentType, permissionMode, model, repoPath string) (*CmdRunner
 
 	// Extract base URL for API client (remove /socketio/ suffix)
 	apiBaseURL := strings.TrimSuffix(wsURL, "/socketio/")
-	// Get agent ID for X-AGENT-ID header (used to disambiguate containers sharing API keys)
-	agentIDForAPI := envManager.Get("NAIRI_AGENT_ID")
-	if agentIDForAPI == "" {
-		agentIDForAPI = envManager.Get("EKSEC_AGENT_ID") // Legacy env var
-	}
-	agentsApiClient := clients.NewAgentsApiClient(nairiAPIKey, apiBaseURL, agentIDForAPI)
+	agentsApiClient := clients.NewAgentsApiClient(nairiAPIKey, apiBaseURL, nairiAgentID)
 	log.Info("🔗 Configured agents API client with base URL: %s", apiBaseURL)
 
 	// Fetch and set Anthropic token BEFORE initializing anything else
@@ -528,8 +571,11 @@ func NewCmdRunner(agentType, permissionMode, model, repoPath string) (*CmdRunner
 
 	gitClient := clients.NewGitClient()
 
-	// Determine state file path
-	statePath := filepath.Join(configDir, "state.json")
+	// Per-agent state file path: {configDir}/agents/{agentID}/state.json
+	statePath, err := env.GetAgentStatePath(nairiAgentID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get agent state path: %w", err)
+	}
 
 	// Restore app state from persisted data
 	appState, agentID, err := handlers.RestoreAppState(statePath)
@@ -569,6 +615,7 @@ func NewCmdRunner(agentType, permissionMode, model, repoPath string) (*CmdRunner
 		appState:        appState,
 		envManager:      envManager,
 		agentID:         agentID,
+		nairiAgentID:    nairiAgentID,
 		agentsApiClient: agentsApiClient,
 		wsURL:           wsURL,
 		nairiAPIKey:     nairiAPIKey,
@@ -778,6 +825,58 @@ func main() {
 		}
 	}()
 
+	// Initialize environment manager early so any .env values are mirrored into
+	// os env before we resolve NAIRI_AGENT_ID. Started here (instead of inside
+	// NewCmdRunner) so the agent lock can be acquired before NewCmdRunner runs
+	// any worktree pool reclaim/cleanup, which is the actual contended resource.
+	envManager, err := env.NewEnvManager()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating environment manager: %v\n", err)
+		os.Exit(1)
+	}
+	envManager.StartPeriodicRefresh(1 * time.Minute)
+
+	// Resolve the agent ID up front (issue #201). Per-instance state/logs/
+	// worktrees are namespaced under this ID, so it must be known before any
+	// of those paths are touched.
+	//
+	// Resolution order (preserves backwards compatibility for self-hosted
+	// users who upgrade nairid without changing their env vars):
+	//   1. NAIRI_AGENT_ID (or legacy EKSEC_AGENT_ID) env var.
+	//   2. Repo mode: derived from the git remote URL of the target repo.
+	//   3. No-repo mode without env var: error (was already required).
+	nairiAgentID, err := resolveNairiAgentIDForStartup(opts.Repo)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	log.Info("🆔 Agent ID for namespacing: %s", nairiAgentID)
+
+	// Lock the per-agent worktree namespace. Two instances with the same
+	// NAIRI_AGENT_ID (e.g. same key reused across repos) would resolve to the
+	// same ~/.eksec_worktrees/agent-{id}/ subtree and corrupt each other's
+	// pool and job worktrees; failing loudly here turns silent corruption
+	// into a clear error (the existing dirLock only covers same CWD).
+	agentBasePath, err := env.GetAgentWorktreeBasePath(nairiAgentID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error resolving agent worktree base path: %v\n", err)
+		os.Exit(1)
+	}
+	agentLock, err := utils.NewDirLock(agentBasePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating agent lock: %v\n", err)
+		os.Exit(1)
+	}
+	if err := agentLock.TryLock(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: another nairid instance is already running with the same agent ID (%s, lock at %s).\nIf this is intentional (e.g. a separate agent in another repo), set a distinct NAIRI_AGENT_ID for this instance.\n", nairiAgentID, agentLock.GetLockPath())
+		os.Exit(1)
+	}
+	defer func() {
+		if unlockErr := agentLock.Unlock(); unlockErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to release agent lock: %v\n", unlockErr)
+		}
+	}()
+
 	// Determine permission mode based on flag
 	permissionMode := "acceptEdits"
 	if opts.BypassPermissions {
@@ -797,7 +896,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	cmdRunner, err := NewCmdRunner(opts.Agent, permissionMode, opts.Model, opts.Repo)
+	cmdRunner, err := NewCmdRunner(envManager, nairiAgentID, opts.Agent, permissionMode, opts.Model, opts.Repo)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error initializing CmdRunner: %v\n", err)
 		os.Exit(1)
@@ -805,6 +904,7 @@ func main() {
 
 	// Store locks in cmdRunner for cleanup
 	cmdRunner.dirLock = dirLock
+	cmdRunner.agentLock = agentLock
 
 	// Setup program-wide logging from start
 	logPath, err := cmdRunner.setupProgramLogging()

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -403,6 +403,13 @@ func resolveNairiAgentIDForStartup(repoFlag string) (string, error) {
 // "github.com/owner/repo") into a filesystem-safe agent ID by replacing path
 // separators with dashes. The agent ID becomes a directory component
 // (~/.eksec_worktrees/agent-{id}/) so slashes would create unintended subdirs.
+//
+// Only path separators are escaped because GetRepositoryIdentifier() already
+// strips the protocol and any auth portion of the URL, leaving an
+// "host/owner/repo" shape — git-hosted URLs use a URL-safe character set, so
+// no other filesystem-unsafe characters are expected in practice. Users who
+// want a stable, human-readable namespace independent of the remote URL can
+// always set NAIRI_AGENT_ID explicitly.
 func sanitizeAgentIDFromRepoIdentifier(repoIdent string) string {
 	safe := strings.ReplaceAll(repoIdent, "/", "-")
 	safe = strings.ReplaceAll(safe, "\\", "-")
@@ -851,6 +858,15 @@ func main() {
 		os.Exit(1)
 	}
 	log.Info("🆔 Agent ID for namespacing: %s", nairiAgentID)
+
+	// Propagate the resolved agent ID into the process env so any downstream
+	// caller of env.GetAgentID() (e.g. GitUseCase.GetWorktreeBasePath via the
+	// worktree pool) sees the same value as the one we just locked, including
+	// the repo-derived fallback case where the user never set NAIRI_AGENT_ID.
+	if err := os.Setenv("NAIRI_AGENT_ID", nairiAgentID); err != nil {
+		fmt.Fprintf(os.Stderr, "Error setting NAIRI_AGENT_ID in process env: %v\n", err)
+		os.Exit(1)
+	}
 
 	// Lock the per-agent worktree namespace. Two instances with the same
 	// NAIRI_AGENT_ID (e.g. same key reused across repos) would resolve to the

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1264,14 +1264,12 @@ func (cr *CmdRunner) startSocketIOClient(serverURLStr, apiKey string) error {
 }
 
 func (cr *CmdRunner) setupProgramLogging() (string, error) {
-	// Get config directory
-	configDir, err := env.GetConfigDir()
+	// Per-agent logs directory so concurrent nairid processes don't share a
+	// single log directory or sweep each other's old log files (issue #201).
+	logsDir, err := env.GetAgentLogsDir(cr.nairiAgentID)
 	if err != nil {
-		return "", fmt.Errorf("failed to get config directory: %w", err)
+		return "", fmt.Errorf("failed to get agent logs directory: %w", err)
 	}
-
-	// Create logs directory
-	logsDir := filepath.Join(configDir, "logs")
 
 	// Set up rotating writer with 10MB file size limit
 	rotatingWriter, err := log.NewRotatingWriter(log.RotatingWriterConfig{

--- a/core/env/agent_id_test.go
+++ b/core/env/agent_id_test.go
@@ -1,0 +1,223 @@
+package env
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withClearedAgentEnv saves and clears NAIRI_AGENT_ID and EKSEC_AGENT_ID for a
+// test, restoring them on cleanup. Returns a setter the test can use to set a
+// specific value during the test body.
+func withClearedAgentEnv(t *testing.T) func(key, val string) {
+	t.Helper()
+	saved := map[string]string{}
+	for _, key := range []string{"NAIRI_AGENT_ID", "EKSEC_AGENT_ID"} {
+		saved[key] = os.Getenv(key)
+		_ = os.Unsetenv(key)
+	}
+	t.Cleanup(func() {
+		for key, val := range saved {
+			if val == "" {
+				_ = os.Unsetenv(key)
+			} else {
+				_ = os.Setenv(key, val)
+			}
+		}
+	})
+	return func(key, val string) {
+		if val == "" {
+			_ = os.Unsetenv(key)
+		} else {
+			_ = os.Setenv(key, val)
+		}
+	}
+}
+
+func TestGetAgentID_PrefersNairiOverLegacy(t *testing.T) {
+	setEnv := withClearedAgentEnv(t)
+	setEnv("NAIRI_AGENT_ID", "my-nairi-agent")
+	setEnv("EKSEC_AGENT_ID", "my-legacy-agent")
+
+	got, err := GetAgentID()
+	if err != nil {
+		t.Fatalf("GetAgentID returned error: %v", err)
+	}
+	if got != "my-nairi-agent" {
+		t.Errorf("expected 'my-nairi-agent', got %q", got)
+	}
+}
+
+func TestGetAgentID_FallsBackToLegacy(t *testing.T) {
+	setEnv := withClearedAgentEnv(t)
+	setEnv("EKSEC_AGENT_ID", "legacy-only")
+
+	got, err := GetAgentID()
+	if err != nil {
+		t.Fatalf("GetAgentID returned error: %v", err)
+	}
+	if got != "legacy-only" {
+		t.Errorf("expected 'legacy-only', got %q", got)
+	}
+}
+
+func TestGetAgentID_ErrorsWhenUnset(t *testing.T) {
+	withClearedAgentEnv(t)
+
+	_, err := GetAgentID()
+	if err == nil {
+		t.Fatal("expected error when both NAIRI_AGENT_ID and EKSEC_AGENT_ID are unset")
+	}
+	if !strings.Contains(err.Error(), "NAIRI_AGENT_ID") {
+		t.Errorf("expected error to mention NAIRI_AGENT_ID, got: %v", err)
+	}
+}
+
+// withTempConfigDir points NAIRI_CONFIG_DIR at a temp dir for the duration of
+// the test, so the env-helpers don't poke at the user's real ~/.config/eksecd.
+func withTempConfigDir(t *testing.T) string {
+	t.Helper()
+	tempDir := t.TempDir()
+	saved := os.Getenv("NAIRI_CONFIG_DIR")
+	_ = os.Setenv("NAIRI_CONFIG_DIR", tempDir)
+	t.Cleanup(func() {
+		if saved == "" {
+			_ = os.Unsetenv("NAIRI_CONFIG_DIR")
+		} else {
+			_ = os.Setenv("NAIRI_CONFIG_DIR", saved)
+		}
+	})
+	return tempDir
+}
+
+func TestGetAgentStatePath_Namespaced(t *testing.T) {
+	tempDir := withTempConfigDir(t)
+
+	got, err := GetAgentStatePath("agent-abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(tempDir, "agents", "agent-abc", "state.json")
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+	// Parent dir must exist (caller writes state.json into it later).
+	if _, err := os.Stat(filepath.Dir(got)); err != nil {
+		t.Errorf("expected parent dir to exist, stat err: %v", err)
+	}
+}
+
+func TestGetAgentStatePath_RejectsEmptyAgentID(t *testing.T) {
+	withTempConfigDir(t)
+	if _, err := GetAgentStatePath(""); err == nil {
+		t.Error("expected error for empty agent ID")
+	}
+}
+
+func TestGetAgentStatePath_DistinctAgentsGetDistinctPaths(t *testing.T) {
+	withTempConfigDir(t)
+
+	a, err := GetAgentStatePath("agent-A")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	b, err := GetAgentStatePath("agent-B")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a == b {
+		t.Errorf("expected distinct state paths for distinct agents, got %q for both", a)
+	}
+}
+
+func TestGetAgentLogsDir_Namespaced(t *testing.T) {
+	tempDir := withTempConfigDir(t)
+
+	got, err := GetAgentLogsDir("agent-xyz")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(tempDir, "logs", "agent-xyz")
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+	if _, err := os.Stat(got); err != nil {
+		t.Errorf("expected logs dir to exist, stat err: %v", err)
+	}
+}
+
+func TestGetAgentLogsDir_RejectsEmptyAgentID(t *testing.T) {
+	withTempConfigDir(t)
+	if _, err := GetAgentLogsDir(""); err == nil {
+		t.Error("expected error for empty agent ID")
+	}
+}
+
+func TestGetAgentWorktreeBasePath_DefaultMode(t *testing.T) {
+	saved := os.Getenv("AGENT_EXEC_USER")
+	_ = os.Unsetenv("AGENT_EXEC_USER")
+	t.Cleanup(func() {
+		if saved == "" {
+			_ = os.Unsetenv("AGENT_EXEC_USER")
+		} else {
+			_ = os.Setenv("AGENT_EXEC_USER", saved)
+		}
+	})
+
+	got, err := GetAgentWorktreeBasePath("agent-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	homeDir, _ := os.UserHomeDir()
+	want := filepath.Join(homeDir, ".eksec_worktrees", "agent-agent-1")
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+func TestGetAgentWorktreeBasePath_ManagedMode(t *testing.T) {
+	saved := os.Getenv("AGENT_EXEC_USER")
+	_ = os.Setenv("AGENT_EXEC_USER", "ccagent")
+	t.Cleanup(func() {
+		if saved == "" {
+			_ = os.Unsetenv("AGENT_EXEC_USER")
+		} else {
+			_ = os.Setenv("AGENT_EXEC_USER", saved)
+		}
+	})
+
+	got, err := GetAgentWorktreeBasePath("agent-2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join("/home", "ccagent", ".eksec_worktrees", "agent-agent-2")
+	if got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+func TestGetAgentWorktreeBasePath_DistinctAgentsGetDistinctPaths(t *testing.T) {
+	a, err := GetAgentWorktreeBasePath("agent-A")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	b, err := GetAgentWorktreeBasePath("agent-B")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a == b {
+		t.Errorf("expected distinct worktree paths for distinct agents, got %q for both", a)
+	}
+	// Crucial property for the issue #201 fix: scans of one agent's subtree
+	// must not see the other agent's subtree.
+	if strings.HasPrefix(a, b) || strings.HasPrefix(b, a) {
+		t.Errorf("agent paths must not be prefixes of each other: %q, %q", a, b)
+	}
+}
+
+func TestGetAgentWorktreeBasePath_RejectsEmptyAgentID(t *testing.T) {
+	if _, err := GetAgentWorktreeBasePath(""); err == nil {
+		t.Error("expected error for empty agent ID")
+	}
+}

--- a/core/env/env_manager.go
+++ b/core/env/env_manager.go
@@ -42,6 +42,77 @@ func NewEnvManager() (*EnvManager, error) {
 	return em, nil
 }
 
+// GetAgentID returns the agent ID from NAIRI_AGENT_ID (or legacy EKSEC_AGENT_ID).
+// This is the user-supplied agent integration ID used to namespace per-instance
+// data on disk so multiple nairid processes on the same machine don't corrupt
+// each other's worktrees, state, or logs (see issue #201).
+func GetAgentID() (string, error) {
+	agentID := os.Getenv("NAIRI_AGENT_ID")
+	if agentID == "" {
+		agentID = os.Getenv("EKSEC_AGENT_ID") // Legacy env var
+	}
+	if agentID == "" {
+		return "", fmt.Errorf("NAIRI_AGENT_ID environment variable is required")
+	}
+	return agentID, nil
+}
+
+// GetAgentStatePath returns the per-agent state file path:
+// {configDir}/agents/{agentID}/state.json. The parent directory is created.
+func GetAgentStatePath(agentID string) (string, error) {
+	if agentID == "" {
+		return "", fmt.Errorf("agent ID cannot be empty")
+	}
+	configDir, err := GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	agentDir := filepath.Join(configDir, "agents", agentID)
+	if err := os.MkdirAll(agentDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create agent state directory: %w", err)
+	}
+	return filepath.Join(agentDir, "state.json"), nil
+}
+
+// GetAgentLogsDir returns the per-agent logs directory:
+// {configDir}/logs/{agentID}/. The directory is created.
+func GetAgentLogsDir(agentID string) (string, error) {
+	if agentID == "" {
+		return "", fmt.Errorf("agent ID cannot be empty")
+	}
+	configDir, err := GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	logsDir := filepath.Join(configDir, "logs", agentID)
+	if err := os.MkdirAll(logsDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create agent logs directory: %w", err)
+	}
+	return logsDir, nil
+}
+
+// GetAgentWorktreeBasePath returns the per-agent worktree base path:
+// ~/.eksec_worktrees/agent-{agentID}/ (or /home/{AGENT_EXEC_USER}/... in managed mode).
+// The directory is NOT created here — callers create it on first use.
+func GetAgentWorktreeBasePath(agentID string) (string, error) {
+	if agentID == "" {
+		return "", fmt.Errorf("agent ID cannot be empty")
+	}
+
+	var rootDir string
+	if execUser := os.Getenv("AGENT_EXEC_USER"); execUser != "" {
+		rootDir = filepath.Join("/home", execUser, ".eksec_worktrees")
+	} else {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to get home directory: %w", err)
+		}
+		rootDir = filepath.Join(homeDir, ".eksec_worktrees")
+	}
+
+	return filepath.Join(rootDir, "agent-"+agentID), nil
+}
+
 // GetConfigDir returns the config directory path, either from NAIRI_CONFIG_DIR
 // environment variable (or legacy EKSEC_CONFIG_DIR) or the default ~/.config/eksecd
 func GetConfigDir() (string, error) {

--- a/usecases/git.go
+++ b/usecases/git.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lucasepe/codename"
 
 	"nairid/clients"
+	"nairid/core/env"
 	"nairid/core/log"
 	"nairid/models"
 	"nairid/services"
@@ -1138,23 +1139,17 @@ func (g *GitUseCase) AbandonJobAndCleanup(jobID, branchName string) error {
 // Worktree-based Concurrent Job Support
 // =============================================================================
 
-// GetWorktreeBasePath returns the base path for nairid worktrees.
-// Worktrees are stored in ~/.eksec_worktrees/
-// If AGENT_EXEC_USER is set (managed mode), worktrees are stored in that user's home
-// directory to ensure they persist on the mounted volume.
+// GetWorktreeBasePath returns the per-agent base path for nairid worktrees:
+// ~/.eksec_worktrees/agent-{agentID}/ (or /home/{AGENT_EXEC_USER}/... in
+// managed mode). Namespacing by agent ID is required so multiple nairid
+// instances under the same $HOME don't corrupt each other's pool/job
+// worktrees during reclaim, cleanup, or replenish scans (see issue #201).
 func (g *GitUseCase) GetWorktreeBasePath() (string, error) {
-	// In managed mode, use the agent execution user's home for persistent storage
-	if execUser := os.Getenv("AGENT_EXEC_USER"); execUser != "" {
-		return filepath.Join("/home", execUser, ".eksec_worktrees"), nil
-	}
-
-	// Default: use current user's home directory
-	homeDir, err := os.UserHomeDir()
+	agentID, err := env.GetAgentID()
 	if err != nil {
-		return "", fmt.Errorf("failed to get home directory: %w", err)
+		return "", fmt.Errorf("failed to resolve agent ID for worktree path: %w", err)
 	}
-
-	return filepath.Join(homeDir, ".eksec_worktrees"), nil
+	return env.GetAgentWorktreeBasePath(agentID)
 }
 
 // GetMaxConcurrency returns the max concurrency setting from environment


### PR DESCRIPTION
Fixes #201.

## Problem

Two or more `nairid` processes on the same machine under the same UNIX user (different repos, distinct `NAIRI_API_KEY`s) currently share a flat `~/.eksec_worktrees/` directory and a single `~/.config/eksecd/state.json`. Three flows in `usecases/worktree_pool.go` walk that shared dir without an ownership check, so instances reclaim, delete, or duplicate each other's worktrees:

1. `ReclaimOrphanedPoolWorktrees` — at startup, reclaims any `pool-*` whose branch starts with `nairid/pool-ready-` or `eksecd/pool-ready-`. Instance B can reclaim Instance A's pool entries and point them at B's repo.
2. `CleanupStaleJobWorktrees` — scans for `j_*` and removes those whose `.git` link looks broken. Instance B's startup can wipe Instance A's live job worktrees.
3. The replenisher races on the shared dir against itself across instances.

`state.json` and the logs dir collide the same way — last-writer-wins on `state.json`, shared 7-day cleanup on logs.

## Fix

Namespace per-instance state under the agent ID:

```
~/.eksec_worktrees/agent-{agentID}/
~/.config/eksecd/agents/{agentID}/state.json
~/.config/eksecd/logs/{agentID}/
```

The three reclaim/cleanup scans now only see their own subdir, so they can't touch another instance's worktrees. State and logs are per-instance with no cross-writer contention.

A second `flock`-style lock on the namespaced worktree base catches the "same agent ID, different CWDs" misconfiguration that the existing `dirLock` can't see (different cwd = different lock). On conflict, the second instance exits with a clear message:

```
Error: another nairid instance is already running with the same agent ID
(github.com-owner-repo, lock at /tmp/eksecd/...). If this is intentional
(e.g. a separate agent in another repo), set a distinct NAIRI_AGENT_ID
for this instance.
```

## Backwards compatibility

Agent ID resolution at startup preserves the existing fallback, so self-hosted users upgrading nairid don't need to change their env vars:

1. **`NAIRI_AGENT_ID`** (or legacy `EKSEC_AGENT_ID`) env var if set.
2. **Repo mode without env var:** derived from the git remote URL (e.g. `github.com/owner/repo` → `github.com-owner-repo`). Same fallback the legacy code already used at `cmd/main.go:989-999`, just resolved earlier so it can drive namespacing.
3. **No-repo mode without env var:** error (was already required).

A self-hosted user with two agents on different repos under the same `\$HOME` upgrades nairid:
- Both instances start without changing env vars.
- Each derives a different repo identifier → different namespaces → no more collision.

A user accidentally running two instances on the **same** repo with no env var:
- Both derive the same identifier → second instance fails on the agent lock with a clear pointer to set `NAIRI_AGENT_ID` if the duplication is intentional.

## Orphaned worktrees and state on upgrade

⚠️ **One-time disruption for self-hosted users.** After upgrade, the new code looks under `~/.eksec_worktrees/agent-{id}/` and `~/.config/eksecd/agents/{id}/state.json`. The existing flat-layout entries are left untouched:

- `~/.eksec_worktrees/{pool-*,j_*}` — orphaned worktrees that consume disk until manually removed.
- `~/.config/eksecd/state.json` — old state file that's no longer read; any in-progress jobs persisted there at the moment of upgrade are lost.
- `~/.config/eksecd/logs/*.log` — old log files left in place.

**Mitigation:** ensure all in-progress jobs are finished before upgrading. After upgrade, operators can clean up the legacy paths manually:

```sh
rm -rf ~/.eksec_worktrees/pool-* ~/.eksec_worktrees/j_*
rm ~/.config/eksecd/state.json
# logs: keep or delete, both are safe
```

No automatic migration is implemented because, in the multi-agent case this PR is fixing, there's no reliable way to attribute a legacy worktree or state entry to a specific agent. Hosted/managed deployments are unaffected — they run nairid in Docker with isolated `\$HOME` per container.

## Implementation notes

- Lock acquisition order in `main()`: cwd dirLock → envManager → resolve agent ID → agent lock → `NewCmdRunner`. The agent lock has to be acquired before `NewCmdRunner` runs because the worktree pool reclaim/cleanup happens inside it.
- `env.GetAgentWorktreeBasePath`, `env.GetAgentStatePath`, `env.GetAgentLogsDir` are the new helpers; all three are package-level so they can be called from both `cmd` and `usecases` without threading the agent ID through every constructor.
- `usecases.GitUseCase.GetWorktreeBasePath()` now delegates to `env.GetAgentWorktreeBasePath` and resolves the agent ID via `env.GetAgentID()`. This works because by the time it's called, agent ID has been validated at startup.
- The duplicated `agentIDForAPI` lookup in the old `NewCmdRunner` is removed — `nairiAgentID` is resolved once and threaded through.

## Test plan

- [ ] `go build ./...` and `go test ./...` pass locally (verified)
- [ ] Run two `nairid` instances on different repos same machine, distinct `NAIRI_API_KEY`s, neither with `NAIRI_AGENT_ID` set → both start, no collision
- [ ] Run two `nairid` instances with the **same** `NAIRI_AGENT_ID` → second exits with the lock-conflict error
- [ ] Run a single instance, complete a job, restart → state recovered from new namespaced path
- [ ] No-repo mode without `NAIRI_AGENT_ID` → fails fast with clear error (unchanged behavior)
- [ ] Self-hosted upgrade path: existing setup with only `NAIRI_API_KEY` set → starts without error using repo-derived agent ID

## Follow-ups (not in this PR)

- Frontend self-host setup page should mention `NAIRI_AGENT_ID` as an optional override (for users who want a stable agent ID independent of the git remote URL — e.g., agents that change repos).
- Optional UX improvement: backend endpoint `GET /api/agents/info` so nairid can resolve its agent ID from the API key without requiring `NAIRI_AGENT_ID` in no-repo mode either. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)