### PR TITLE
fix(windows): pipe agent prompt via stdin to avoid cmd.exe truncation

### DIFF
--- a/clients/claude/claude.go
+++ b/clients/claude/claude.go
@@ -28,8 +28,10 @@ func (c *ClaudeClient) StartNewSession(prompt string, options *clients.ClaudeOpt
 	args = append(args,
 		"--verbose",
 		"--output-format", "stream-json",
-		"-p", prompt,
+		"-p",
 	)
+	promptArgs, promptStdin := clients.ApplyPrompt(prompt)
+	args = append(args, promptArgs...)
 
 	if options != nil {
 		if options.Model != "" {
@@ -51,6 +53,9 @@ func (c *ClaudeClient) StartNewSession(prompt string, options *clients.ClaudeOpt
 	defer cancel()
 
 	cmd := c.buildCommand(ctx, options, args)
+	if promptStdin != nil {
+		cmd.Stdin = promptStdin
+	}
 
 	log.Info("Running Claude command (timeout: %s)", clients.DefaultSessionTimeout)
 	result, err := clients.RunCommandStreaming(ctx, cmd, onLine)
@@ -70,8 +75,10 @@ func (c *ClaudeClient) ContinueSession(sessionID, prompt string, options *client
 		"--verbose",
 		"--output-format", "stream-json",
 		"--resume", sessionID,
-		"-p", prompt,
+		"-p",
 	)
+	promptArgs, promptStdin := clients.ApplyPrompt(prompt)
+	args = append(args, promptArgs...)
 
 	if options != nil {
 		if options.Model != "" {
@@ -93,6 +100,9 @@ func (c *ClaudeClient) ContinueSession(sessionID, prompt string, options *client
 	defer cancel()
 
 	cmd := c.buildCommand(ctx, options, args)
+	if promptStdin != nil {
+		cmd.Stdin = promptStdin
+	}
 
 	log.Info("Running Claude command (timeout: %s)", clients.DefaultSessionTimeout)
 	result, err := clients.RunCommandStreaming(ctx, cmd, onLine)

--- a/clients/prompt_unix.go
+++ b/clients/prompt_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package clients
+
+import "io"
+
+// ApplyPrompt returns the positional argument(s) to append to an agent CLI
+// command for prompt delivery, plus an optional stdin reader the caller
+// should attach to the command before launching it.
+//
+// On Unix-like systems the prompt is delivered as a positional CLI
+// argument and stdin is left untouched (returns nil reader).
+func ApplyPrompt(prompt string) ([]string, io.Reader) {
+	return []string{prompt}, nil
+}

--- a/clients/prompt_unix_test.go
+++ b/clients/prompt_unix_test.go
@@ -1,0 +1,39 @@
+//go:build !windows
+
+package clients
+
+import (
+	"testing"
+)
+
+func TestApplyPrompt_Unix(t *testing.T) {
+	tests := []struct {
+		name   string
+		prompt string
+	}{
+		{name: "empty prompt", prompt: ""},
+		{name: "single line", prompt: "hello"},
+		{
+			name:   "slack sender header (multi-line)",
+			prompt: "[Sender: Pres (pmihaylov95@gmail.com) via slack]\n\n@nairi tell me what day we are today",
+		},
+		{name: "code block with newlines", prompt: "fix this:\n```go\nfmt.Println(\"hi\")\n```"},
+		{name: "shell metacharacters", prompt: "do `rm -rf /tmp/x` & ls | grep foo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args, stdin := ApplyPrompt(tt.prompt)
+
+			if stdin != nil {
+				t.Errorf("expected nil stdin reader on Unix, got %T", stdin)
+			}
+			if len(args) != 1 {
+				t.Fatalf("expected exactly 1 positional arg, got %d: %v", len(args), args)
+			}
+			if args[0] != tt.prompt {
+				t.Errorf("expected positional arg to be the prompt verbatim, got %q want %q", args[0], tt.prompt)
+			}
+		})
+	}
+}

--- a/clients/prompt_windows.go
+++ b/clients/prompt_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package clients
+
+import (
+	"io"
+	"strings"
+)
+
+// ApplyPrompt returns the positional argument(s) to append to an agent CLI
+// command for prompt delivery, plus an optional stdin reader the caller
+// should attach to the command before launching it.
+//
+// On Windows the prompt is delivered via stdin instead of as a CLI
+// argument. Agent CLIs (claude, codex, opencode, cursor-agent) are
+// typically installed as .cmd batch shims via npm. cmd.exe truncates
+// arguments at embedded newlines when expanding %* inside the shim, so
+// a multi-line prompt (e.g. one carrying the "[Sender: ...]\n\n<msg>"
+// header for Slack/Discord messages, or any user-supplied multi-line
+// content) reaches the agent with everything after the first newline
+// stripped off, leaving the agent with what looks like an empty input.
+//
+// Stdin pipes go directly from the parent process into the child via
+// the Windows kernel and bypass cmd.exe's argument parsing entirely,
+// so newlines and other shell metacharacters are preserved verbatim.
+func ApplyPrompt(prompt string) ([]string, io.Reader) {
+	return nil, strings.NewReader(prompt)
+}

--- a/clients/prompt_windows_test.go
+++ b/clients/prompt_windows_test.go
@@ -1,0 +1,45 @@
+//go:build windows
+
+package clients
+
+import (
+	"io"
+	"testing"
+)
+
+func TestApplyPrompt_Windows(t *testing.T) {
+	tests := []struct {
+		name   string
+		prompt string
+	}{
+		{name: "empty prompt", prompt: ""},
+		{name: "single line", prompt: "hello"},
+		{
+			name:   "slack sender header (multi-line)",
+			prompt: "[Sender: Pres (pmihaylov95@gmail.com) via slack]\n\n@nairi tell me what day we are today",
+		},
+		{name: "code block with newlines", prompt: "fix this:\n```go\nfmt.Println(\"hi\")\n```"},
+		{name: "shell metacharacters", prompt: "do `rm -rf /tmp/x` & ls | grep foo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args, stdin := ApplyPrompt(tt.prompt)
+
+			if args != nil {
+				t.Errorf("expected nil positional args on Windows (prompt should travel via stdin), got %v", args)
+			}
+			if stdin == nil {
+				t.Fatal("expected non-nil stdin reader on Windows")
+			}
+
+			read, err := io.ReadAll(stdin)
+			if err != nil {
+				t.Fatalf("failed to read stdin: %v", err)
+			}
+			if string(read) != tt.prompt {
+				t.Errorf("stdin should contain the prompt verbatim, got %q want %q", string(read), tt.prompt)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes a Windows-only bug where Slack/Discord messages reach the Claude agent as empty content because `cmd.exe`'s batch-line interpreter truncates the `-p` argument at the first embedded newline.
- The bug surfaces on every Slack/Discord message (the `prependSenderMetadata` helper at `handlers/messages.go:1186` injects a `[Sender: ...]\n\n<msg>` header), and also on any user prompt containing a newline (Shift+Enter, code blocks, multi-line questions, thread context, future attachment markers, etc.).
- Tasks UI / web messages were unaffected because `PlatformWeb` is declared but never instantiated by the backend, so those payloads carry `SenderMetadata == nil` and stay single-line.

## Root cause

On Windows, `claude` is typically installed as a `.cmd` batch shim (npm-published). When Go's `exec.Cmd` resolves the binary, the prompt argument flows through `cmd.exe`'s argv expansion inside the shim. Embedded `\n` characters terminate the command line, so everything after the first newline gets dropped before the agent ever sees it.

Production logs from a Windows nairid (excerpt):

```
prompt: [Sender: Stoyan Stoyanov (...) via slack]\n\n@nairi tell me what day we are today
```

The agent process ran successfully (stream-json output, no errors) but received an effectively empty user prompt and replied: *"I see your message came through Slack, but it appears to be empty…"*.

## Fix

Introduce a build-tag-isolated `clients.ApplyPrompt(prompt) ([]string, io.Reader)` helper:

| Platform | Behaviour |
|---|---|
| `!windows` (linux, darwin, …) | Returns `([]string{prompt}, nil)` — identical to the prior `args = append(args, "-p", prompt)` shape. **No behaviour change.** |
| `windows` | Returns `(nil, strings.NewReader(prompt))` — the prompt rides `cmd.Stdin`, bypassing `cmd.exe`'s argument parsing entirely. Newlines and shell metacharacters are preserved verbatim. |

The Claude CLI accepts the prompt over stdin when `-p` is present without a positional value (verified locally; an empty stdin produces the documented error *"Input must be provided either through stdin or as a prompt argument when using --print"*).

`clients/claude/claude.go` is updated to call `ApplyPrompt` in both `StartNewSession` and `ContinueSession`. Args ordering on Unix is byte-equivalent to the prior shape; only the Windows binary changes.

## Blast radius

- **Linux servers / production fleet** — zero behaviour change. Compiled machine code in this region is identical (the `!windows` build tag means `prompt_windows.go` is not even parsed).
- **macOS** — zero behaviour change.
- **Windows self-hosted** — gets the stdin path; the bug is fixed.

## Tests

Added unit coverage in `clients/prompt_unix_test.go` and `clients/prompt_windows_test.go` (each behind matching build tags). Both cover the bug-triggering case (Slack sender header + multi-line body) plus single-line, empty, code-block, and shell-metacharacter prompts:

- `TestApplyPrompt_Unix` — asserts the prompt is returned as a single positional arg and stdin is `nil`.
- `TestApplyPrompt_Windows` — asserts no positional arg is returned and the stdin reader produces the prompt verbatim.

## CI checks (run locally)

| Check | Result |
|---|---|
| `make build` (linux) | OK |
| `GOOS=windows GOARCH=amd64 go build` | OK |
| `make test` | OK — all packages pass |
| `goimports -d` on changed files | OK — no diff |
| `golines --max-len=120 --dry-run` on changed files | OK — the warnings shown also exist on `main` (pre-existing long function signatures, untouched by this PR) |
| `golangci-lint run --timeout=5m ./clients/...` | OK — 0 issues |
| `go vet ./...` (linux) | OK |
| `go vet` (windows) | one pre-existing warning in `clients/process_test.go:605` unrelated to this change |

## Out of scope (follow-ups)

`codex`, `opencode`, and `cursor-agent` pass the prompt the same way and likely have the same latent bug on Windows, but their stdin semantics differ:

- `codex exec` reads stdin when no positional is given (works the same as claude).
- `codex exec resume` requires an explicit `-` sentinel positional to read stdin (per `codex exec resume --help`).
- `opencode run` stdin behaviour is undocumented from `--help` output.
- `cursor-agent` was not available locally for verification.

Better to verify those individually rather than ship a speculative fix that could regress them. Tracked as follow-up work.

## Test plan
- [ ] On a Windows host with nairid running, send a multi-line Slack message to the bound agent and verify the agent receives the full body (not just the first line / Sender header).
- [ ] Verify Tasks UI behaviour on the same Windows host is unchanged.
- [ ] Verify Linux/macOS hosts behave identically to before (smoke test on at least one v2 host post-rollout).
- [ ] Confirm PR CI lane is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)