### PR TITLE
fix: drop orphan worktrees when git refuses, accept job_ prefix

### DIFF
--- a/usecases/git.go
+++ b/usecases/git.go
@@ -1473,13 +1473,21 @@ func (g *GitUseCase) CleanupOrphanedWorktrees() error {
 		if !trackedWorktrees[worktreePath] {
 			log.Info("🗑️ Found orphaned worktree: %s", worktreePath)
 
-			// Remove the worktree
+			// Remove the worktree via git first
 			if err := g.gitClient.RemoveWorktree(worktreePath); err != nil {
-				log.Warn("⚠️ Failed to remove orphaned worktree %s: %v", worktreePath, err)
-				// Continue with other worktrees
-			} else {
-				orphanedCount++
+				// Fallback: when git can no longer reconcile the worktree (e.g. the bare
+				// repo's .git/worktrees/ has been wiped, or the worktree was never
+				// registered) git refuses to remove it. Drop the directory directly so
+				// the orphan doesn't accumulate on disk forever. Mirrors the pattern in
+				// cleanupFailedWorktree and CleanupStaleJobWorktrees.
+				log.Warn("⚠️ Failed to remove orphaned worktree via git %s: %v, falling back to os.RemoveAll", worktreePath, err)
+				if rmErr := os.RemoveAll(worktreePath); rmErr != nil {
+					log.Warn("⚠️ Failed to remove orphaned worktree directory %s: %v", worktreePath, rmErr)
+					// Continue with other worktrees
+					continue
+				}
 			}
+			orphanedCount++
 		}
 	}
 

--- a/usecases/git_test.go
+++ b/usecases/git_test.go
@@ -1,0 +1,123 @@
+package usecases
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"nairid/clients"
+	"nairid/models"
+)
+
+// TestCleanupOrphanedWorktrees_FallbackOnGitFailure verifies that when
+// `git worktree remove` fails (for example because the bare repo's
+// .git/worktrees/ directory has been wiped), CleanupOrphanedWorktrees falls
+// back to os.RemoveAll so the orphan directory is still removed.
+//
+// Regression: prior to the fix, `CleanupOrphanedWorktrees` only logged a
+// warning when git refused to remove the worktree and left the directory on
+// disk forever. On a host whose bare repo lost its worktrees registry, this
+// caused tens of GB of orphaned job worktree directories to accumulate over
+// time because the periodic cleanup hit the same git failure on every tick.
+func TestCleanupOrphanedWorktrees_FallbackOnGitFailure(t *testing.T) {
+	mainRepo, worktreeBase, cleanup := setupTestGitRepoWithRemote(t)
+	defer cleanup()
+
+	gitClient := clients.NewGitClient()
+	gitClient.SetRepoPathProvider(func() string { return mainRepo })
+
+	appState := models.NewAppState("test-agent", filepath.Join(worktreeBase, "state.json"))
+	appState.SetRepositoryContext(&models.RepositoryContext{
+		RepoPath:   mainRepo,
+		IsRepoMode: true,
+	})
+
+	gitUseCase := NewGitUseCase(gitClient, nil, appState)
+	// GetWorktreeBasePath honors AGENT_EXEC_USER and falls back to $HOME, so
+	// override $HOME for the duration of the test to point at our temp dir.
+	t.Setenv("AGENT_EXEC_USER", "")
+	t.Setenv("HOME", worktreeBase)
+
+	// The function expects ~/.eksec_worktrees as the base path; create that
+	// layout under our temp HOME and place an orphan directory inside it.
+	resolvedBase, err := gitUseCase.GetWorktreeBasePath()
+	if err != nil {
+		t.Fatalf("Failed to get worktree base path: %v", err)
+	}
+	if err := os.MkdirAll(resolvedBase, 0755); err != nil {
+		t.Fatalf("Failed to create worktree base path: %v", err)
+	}
+
+	// Create a directory that LOOKS like a worktree but is not registered with
+	// git — simulating the post-wipe state where .git/worktrees/ has no entry
+	// for it. `git worktree remove` will fail on this path.
+	orphanPath := filepath.Join(resolvedBase, "job_01KQORPHANEDWORKTREEXYZ")
+	if err := os.MkdirAll(orphanPath, 0755); err != nil {
+		t.Fatalf("Failed to create orphan directory: %v", err)
+	}
+	// Drop a file inside so we can also verify recursive removal.
+	if err := os.WriteFile(filepath.Join(orphanPath, "marker"), []byte("orphan"), 0644); err != nil {
+		t.Fatalf("Failed to write marker file: %v", err)
+	}
+
+	if err := gitUseCase.CleanupOrphanedWorktrees(); err != nil {
+		t.Fatalf("CleanupOrphanedWorktrees failed: %v", err)
+	}
+
+	if _, err := os.Stat(orphanPath); !os.IsNotExist(err) {
+		t.Errorf("Orphan worktree directory was not removed via fallback: %v", err)
+	}
+}
+
+// TestCleanupOrphanedWorktrees_SkipsTrackedWorktrees verifies that worktrees
+// referenced by a tracked job are never touched, even if `git worktree remove`
+// would also fail on them.
+func TestCleanupOrphanedWorktrees_SkipsTrackedWorktrees(t *testing.T) {
+	mainRepo, worktreeBase, cleanup := setupTestGitRepoWithRemote(t)
+	defer cleanup()
+
+	gitClient := clients.NewGitClient()
+	gitClient.SetRepoPathProvider(func() string { return mainRepo })
+
+	appState := models.NewAppState("test-agent", filepath.Join(worktreeBase, "state.json"))
+	appState.SetRepositoryContext(&models.RepositoryContext{
+		RepoPath:   mainRepo,
+		IsRepoMode: true,
+	})
+
+	gitUseCase := NewGitUseCase(gitClient, nil, appState)
+	t.Setenv("AGENT_EXEC_USER", "")
+	t.Setenv("HOME", worktreeBase)
+
+	resolvedBase, err := gitUseCase.GetWorktreeBasePath()
+	if err != nil {
+		t.Fatalf("Failed to get worktree base path: %v", err)
+	}
+	if err := os.MkdirAll(resolvedBase, 0755); err != nil {
+		t.Fatalf("Failed to create worktree base path: %v", err)
+	}
+
+	trackedPath := filepath.Join(resolvedBase, "job_01KQTRACKEDXYZ123456789")
+	if err := os.MkdirAll(trackedPath, 0755); err != nil {
+		t.Fatalf("Failed to create tracked directory: %v", err)
+	}
+
+	// Register the path with appState so CleanupOrphanedWorktrees treats it
+	// as live.
+	if err := appState.UpdateJobData("job_01KQTRACKEDXYZ123456789", models.JobData{
+		JobID:        "job_01KQTRACKEDXYZ123456789",
+		BranchName:   "nairid/test-branch",
+		WorktreePath: trackedPath,
+		Status:       models.JobStatusInProgress,
+	}); err != nil {
+		t.Fatalf("Failed to register tracked job: %v", err)
+	}
+
+	if err := gitUseCase.CleanupOrphanedWorktrees(); err != nil {
+		t.Fatalf("CleanupOrphanedWorktrees failed: %v", err)
+	}
+
+	if _, err := os.Stat(trackedPath); os.IsNotExist(err) {
+		t.Error("Tracked worktree was incorrectly removed")
+	}
+}

--- a/usecases/worktree_pool.go
+++ b/usecases/worktree_pool.go
@@ -489,10 +489,11 @@ func (p *WorktreePool) CleanupPool() error {
 	return nil
 }
 
-// CleanupStaleJobWorktrees scans the base path for j_* directories (job worktrees)
-// that have broken git references and removes them. This can happen when containers
-// are recreated - the volume preserves old job worktrees but the main repo's
-// .git/worktrees/ directory gets recreated fresh, breaking the git links.
+// CleanupStaleJobWorktrees scans the base path for job worktree directories
+// (j_* legacy and job_* current naming) that have broken git references and
+// removes them. This can happen when containers are recreated - the volume
+// preserves old job worktrees but the main repo's .git/worktrees/ directory
+// gets recreated fresh, breaking the git links.
 func (p *WorktreePool) CleanupStaleJobWorktrees() error {
 	log.Info("🔍 Scanning for stale job worktrees with broken git references")
 
@@ -515,8 +516,10 @@ func (p *WorktreePool) CleanupStaleJobWorktrees() error {
 			continue
 		}
 
-		// Only process j_* directories (job worktrees)
-		if !strings.HasPrefix(entry.Name(), "j_") {
+		// Only process job worktree directories. Both j_* (legacy) and job_*
+		// (current, post-rename) prefixes are accepted.
+		name := entry.Name()
+		if !strings.HasPrefix(name, "j_") && !strings.HasPrefix(name, "job_") {
 			continue
 		}
 

--- a/usecases/worktree_pool_test.go
+++ b/usecases/worktree_pool_test.go
@@ -612,6 +612,48 @@ func TestCleanupStaleJobWorktrees(t *testing.T) {
 	_ = gitClient.DeleteLocalBranch(branchName)
 }
 
+// TestCleanupStaleJobWorktrees_AcceptsJobPrefix verifies that the cleanup
+// scans both the legacy "j_*" and the current "job_*" prefixes. Without
+// support for "job_*", agents on the post-rename naming convention will
+// silently accumulate broken worktree directories on disk.
+func TestCleanupStaleJobWorktrees_AcceptsJobPrefix(t *testing.T) {
+	mainRepo, worktreeBase, cleanup := setupTestGitRepoWithRemote(t)
+	defer cleanup()
+
+	gitClient := clients.NewGitClient()
+	gitClient.SetRepoPathProvider(func() string { return mainRepo })
+
+	// Create a broken worktree using the current "job_" prefix (directory
+	// exists but .git points to a non-existent gitdir).
+	brokenJobPath := filepath.Join(worktreeBase, "job_01KQABCDEFGHJKMNPQRSTVWXYZ")
+	if err := os.MkdirAll(brokenJobPath, 0755); err != nil {
+		t.Fatalf("Failed to create broken job_ directory: %v", err)
+	}
+	gitFilePath := filepath.Join(brokenJobPath, ".git")
+	if err := os.WriteFile(gitFilePath, []byte("gitdir: /nonexistent/path/.git/worktrees/broken"), 0644); err != nil {
+		t.Fatalf("Failed to create broken .git file: %v", err)
+	}
+
+	// Also create an unrelated directory that should NOT be touched.
+	untouchedPath := filepath.Join(worktreeBase, "some-unrelated-dir")
+	if err := os.MkdirAll(untouchedPath, 0755); err != nil {
+		t.Fatalf("Failed to create unrelated dir: %v", err)
+	}
+
+	pool := NewWorktreePool(gitClient, worktreeBase, 3)
+
+	if err := pool.CleanupStaleJobWorktrees(); err != nil {
+		t.Fatalf("CleanupStaleJobWorktrees failed: %v", err)
+	}
+
+	if _, err := os.Stat(brokenJobPath); !os.IsNotExist(err) {
+		t.Error("Broken job_-prefixed worktree was not removed")
+	}
+	if _, err := os.Stat(untouchedPath); os.IsNotExist(err) {
+		t.Error("Unrelated directory was incorrectly removed")
+	}
+}
+
 func TestStartAndStop(t *testing.T) {
 	gitClient := clients.NewGitClient()
 	pool := NewWorktreePool(gitClient, "/tmp/nonexistent", 1)


### PR DESCRIPTION
## Summary

Two bugs in worktree cleanup that left job worktree directories on disk indefinitely on long-lived agent containers, accumulating to tens of GB on busy agents.

### Bug #1 — `CleanupOrphanedWorktrees` had no `os.RemoveAll` fallback

`usecases/git.go` `CleanupOrphanedWorktrees` shells out to `git worktree remove --force`. When the bare repo's `.git/worktrees/` directory has been wiped (or the worktree was never registered), git refuses to remove it. The function previously logged a warning and moved on, so on every periodic 10-min cleanup tick the same orphan was re-discovered and re-skipped.

Fix: on git failure, fall back to `os.RemoveAll(worktreePath)` so the directory is removed regardless of git's view. Mirrors the pattern already used in `cleanupFailedWorktree` and `CleanupStaleJobWorktrees` in `worktree_pool.go`.

### Bug #2 — `CleanupStaleJobWorktrees` only accepted `j_*` prefix

`usecases/worktree_pool.go` `CleanupStaleJobWorktrees` filtered by `strings.HasPrefix(name, \"j_\")` and silently skipped the current `job_*` naming convention.

Fix: accept both `j_*` (legacy) and `job_*` (current) prefixes.

## Tests

Three new tests, all passing:

- `TestCleanupOrphanedWorktrees_FallbackOnGitFailure` — creates a directory under the worktree base path that is **not** a registered git worktree, runs cleanup, asserts the directory is gone. Without the fix the directory would still exist.
- `TestCleanupOrphanedWorktrees_SkipsTrackedWorktrees` — guards against accidental removal of worktrees referenced by tracked jobs.
- `TestCleanupStaleJobWorktrees_AcceptsJobPrefix` — creates a broken \`job_*\` worktree (and an unrelated dir), runs cleanup, asserts the broken \`job_*\` is removed and the unrelated dir is left alone.

Existing `TestCleanupStaleJobWorktrees` continues to pass.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test -count=1 ./usecases/...\` passes (4/4 cleanup tests, including the original)
- [x] \`go test -count=1 ./...\` full suite passes
- [ ] After merge + redeploy, verify periodic cleanup self-heals the orphan worktrees on the affected agent (no manual \`rm\` on the host required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)