### PR TITLE
fix: clean skills directory when zero skills are enabled

### DIFF
--- a/utils/skills_processor.go
+++ b/utils/skills_processor.go
@@ -291,11 +291,6 @@ func (p *ClaudeCodeSkillsProcessor) ProcessSkills(targetHomeDir string) error {
 		return fmt.Errorf("failed to get skill files: %w", err)
 	}
 
-	if len(skillFiles) == 0 {
-		log.Info("🎯 No skills found in eksecd skills directory")
-		return nil
-	}
-
 	log.Info("🎯 Found %d skill file(s) to process", len(skillFiles))
 
 	// Determine home directory for Claude Code skills
@@ -313,7 +308,9 @@ func (p *ClaudeCodeSkillsProcessor) ProcessSkills(targetHomeDir string) error {
 	// Target directory: ~/.claude/skills/
 	claudeSkillsDir := filepath.Join(homeDir, ".claude", "skills")
 
-	// Clean up existing skills directory to avoid stale skills
+	// Clean up existing skills directory to avoid stale skills.
+	// Must run even when skillFiles is empty so that skills disabled on the
+	// server (leaving zero skills enabled) are removed from the container.
 	log.Info("🎯 Cleaning Claude Code skills directory: %s", claudeSkillsDir)
 	if err := removeAllAsTargetUser(claudeSkillsDir); err != nil && !os.IsNotExist(err) {
 		log.Info("⚠️  Failed to remove existing skills directory: %v", err)
@@ -322,6 +319,11 @@ func (p *ClaudeCodeSkillsProcessor) ProcessSkills(targetHomeDir string) error {
 	// Create fresh skills directory
 	if err := mkdirAllAsTargetUser(claudeSkillsDir); err != nil {
 		return fmt.Errorf("failed to create Claude skills directory: %w", err)
+	}
+
+	if len(skillFiles) == 0 {
+		log.Info("🎯 No skills to extract; skills directory cleaned")
+		return nil
 	}
 
 	// Extract each skill ZIP to its own directory
@@ -375,11 +377,6 @@ func (p *OpenCodeSkillsProcessor) ProcessSkills(targetHomeDir string) error {
 		return fmt.Errorf("failed to get skill files: %w", err)
 	}
 
-	if len(skillFiles) == 0 {
-		log.Info("🎯 No skills found in eksecd skills directory")
-		return nil
-	}
-
 	log.Info("🎯 Found %d skill file(s) to process", len(skillFiles))
 
 	// Determine home directory for OpenCode skills
@@ -397,7 +394,9 @@ func (p *OpenCodeSkillsProcessor) ProcessSkills(targetHomeDir string) error {
 	// Target directory: ~/.config/opencode/skill/
 	opencodeSkillsDir := filepath.Join(homeDir, ".config", "opencode", "skill")
 
-	// Clean up existing skills directory to avoid stale skills
+	// Clean up existing skills directory to avoid stale skills.
+	// Must run even when skillFiles is empty so that skills disabled on the
+	// server (leaving zero skills enabled) are removed from the container.
 	log.Info("🎯 Cleaning OpenCode skills directory: %s", opencodeSkillsDir)
 	if err := removeAllAsTargetUser(opencodeSkillsDir); err != nil && !os.IsNotExist(err) {
 		log.Info("⚠️  Failed to remove existing skills directory: %v", err)
@@ -406,6 +405,11 @@ func (p *OpenCodeSkillsProcessor) ProcessSkills(targetHomeDir string) error {
 	// Create fresh skills directory with correct ownership
 	if err := mkdirAllAsTargetUser(opencodeSkillsDir); err != nil {
 		return fmt.Errorf("failed to create OpenCode skills directory: %w", err)
+	}
+
+	if len(skillFiles) == 0 {
+		log.Info("🎯 No skills to extract; skills directory cleaned")
+		return nil
 	}
 
 	// Extract each skill ZIP to its own directory
@@ -459,11 +463,6 @@ func (p *CodexSkillsProcessor) ProcessSkills(targetHomeDir string) error {
 		return fmt.Errorf("failed to get skill files: %w", err)
 	}
 
-	if len(skillFiles) == 0 {
-		log.Info("🎯 No skills found in eksecd skills directory")
-		return nil
-	}
-
 	log.Info("🎯 Found %d skill file(s) to process", len(skillFiles))
 
 	// Determine home directory for Codex skills
@@ -481,7 +480,9 @@ func (p *CodexSkillsProcessor) ProcessSkills(targetHomeDir string) error {
 	// Target directory: ~/.codex/skills/
 	codexSkillsDir := filepath.Join(homeDir, ".codex", "skills")
 
-	// Clean up existing skills directory to avoid stale skills
+	// Clean up existing skills directory to avoid stale skills.
+	// Must run even when skillFiles is empty so that skills disabled on the
+	// server (leaving zero skills enabled) are removed from the container.
 	log.Info("🎯 Cleaning Codex skills directory: %s", codexSkillsDir)
 	if err := removeAllAsTargetUser(codexSkillsDir); err != nil && !os.IsNotExist(err) {
 		log.Info("⚠️  Failed to remove existing skills directory: %v", err)
@@ -490,6 +491,11 @@ func (p *CodexSkillsProcessor) ProcessSkills(targetHomeDir string) error {
 	// Create fresh skills directory
 	if err := mkdirAllAsTargetUser(codexSkillsDir); err != nil {
 		return fmt.Errorf("failed to create Codex skills directory: %w", err)
+	}
+
+	if len(skillFiles) == 0 {
+		log.Info("🎯 No skills to extract; skills directory cleaned")
+		return nil
 	}
 
 	// Extract each skill ZIP to its own directory

--- a/utils/skills_processor_test.go
+++ b/utils/skills_processor_test.go
@@ -878,14 +878,94 @@ func TestCodexSkillsProcessor_NoSkills(t *testing.T) {
 	t.Setenv("HOME", tmpDir)
 	defer func() { _ = os.Setenv("HOME", originalHome) }()
 
+	// Pre-create a stale skill that should be wiped because no skills are enabled.
+	codexSkillsDir := filepath.Join(tmpDir, ".codex", "skills")
+	staleSkillDir := filepath.Join(codexSkillsDir, "stale-skill")
+	if err := os.MkdirAll(staleSkillDir, 0755); err != nil {
+		t.Fatalf("Failed to seed stale skill directory: %v", err)
+	}
+	stalePath := filepath.Join(staleSkillDir, "SKILL.md")
+	if err := os.WriteFile(stalePath, []byte("stale"), 0644); err != nil {
+		t.Fatalf("Failed to seed stale skill file: %v", err)
+	}
+
 	processor := NewCodexSkillsProcessor()
 	if err := processor.ProcessSkills(""); err != nil {
 		t.Fatalf("Expected no error, got: %v", err)
 	}
 
-	codexSkillsDir := filepath.Join(tmpDir, ".codex", "skills")
-	if _, err := os.Stat(codexSkillsDir); !os.IsNotExist(err) {
-		t.Errorf("Expected skills directory not to exist when no skills")
+	// Skills directory should exist (freshly created) but be empty —
+	// any previously extracted skills must be removed.
+	entries, err := os.ReadDir(codexSkillsDir)
+	if err != nil {
+		t.Fatalf("Expected empty skills directory to exist, got error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("Expected empty skills directory, but found %d entries", len(entries))
+	}
+}
+
+func TestClaudeCodeSkillsProcessor_NoSkills(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	originalHome := os.Getenv("HOME")
+	t.Setenv("HOME", tmpDir)
+	defer func() { _ = os.Setenv("HOME", originalHome) }()
+
+	// Pre-create a stale skill that should be wiped because no skills are enabled.
+	claudeSkillsDir := filepath.Join(tmpDir, ".claude", "skills")
+	staleSkillDir := filepath.Join(claudeSkillsDir, "stale-skill")
+	if err := os.MkdirAll(staleSkillDir, 0755); err != nil {
+		t.Fatalf("Failed to seed stale skill directory: %v", err)
+	}
+	stalePath := filepath.Join(staleSkillDir, "SKILL.md")
+	if err := os.WriteFile(stalePath, []byte("stale"), 0644); err != nil {
+		t.Fatalf("Failed to seed stale skill file: %v", err)
+	}
+
+	processor := NewClaudeCodeSkillsProcessor()
+	if err := processor.ProcessSkills(""); err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	entries, err := os.ReadDir(claudeSkillsDir)
+	if err != nil {
+		t.Fatalf("Expected empty skills directory to exist, got error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("Expected empty skills directory, but found %d entries", len(entries))
+	}
+}
+
+func TestOpenCodeSkillsProcessor_NoSkills(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	originalHome := os.Getenv("HOME")
+	t.Setenv("HOME", tmpDir)
+	defer func() { _ = os.Setenv("HOME", originalHome) }()
+
+	// Pre-create a stale skill that should be wiped because no skills are enabled.
+	opencodeSkillsDir := filepath.Join(tmpDir, ".config", "opencode", "skill")
+	staleSkillDir := filepath.Join(opencodeSkillsDir, "stale-skill")
+	if err := os.MkdirAll(staleSkillDir, 0755); err != nil {
+		t.Fatalf("Failed to seed stale skill directory: %v", err)
+	}
+	stalePath := filepath.Join(staleSkillDir, "SKILL.md")
+	if err := os.WriteFile(stalePath, []byte("stale"), 0644); err != nil {
+		t.Fatalf("Failed to seed stale skill file: %v", err)
+	}
+
+	processor := NewOpenCodeSkillsProcessor()
+	if err := processor.ProcessSkills(""); err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	entries, err := os.ReadDir(opencodeSkillsDir)
+	if err != nil {
+		t.Fatalf("Expected empty skills directory to exist, got error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("Expected empty skills directory, but found %d entries", len(entries))
 	}
 }
 


### PR DESCRIPTION
## Summary

- \`ProcessSkills\` returned early when no skill files were present, **before** wiping the agent-specific skills directory (e.g. \`~/.claude/skills\`). As a result, when the last skill on an agent was disabled the previously extracted skills stayed on disk and the agent kept loading them.
- Moved the empty check to **after** the cleanup so the directory is always reset to a fresh, empty state regardless of how many skills are enabled. Same fix applied to the Claude Code, OpenCode, and Codex processors.
- Added regression tests for all three processors: seed a stale skill, run \`ProcessSkills\`, assert the directory is empty.

The bug only triggers when going from N enabled skills → 0. Partial unchecks (e.g. 5 → 4) already work because the empty-check path is skipped.

## Test plan

- [x] \`go build ./...\` succeeds
- [x] \`go test ./utils/...\` passes, including the new \`TestClaudeCodeSkillsProcessor_NoSkills\`, \`TestOpenCodeSkillsProcessor_NoSkills\`, and updated \`TestCodexSkillsProcessor_NoSkills\`
- [ ] Verify on a real container after release: enable a skill on an agent, then disable it, redeploy, and confirm \`~/.claude/skills/\` is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)