### PR TITLE
fix: prune stale refs on git fetch to recover from D/F conflicts

### DIFF
--- a/clients/git.go
+++ b/clients/git.go
@@ -1229,9 +1229,16 @@ func (g *GitClient) UpdateRemoteURLWithToken(token string) error {
 
 // FetchOrigin fetches updates from the origin remote.
 // This is safe for concurrent calls as it only updates remote tracking refs.
+//
+// --prune is required: without it, a stale local remote-tracking ref for an
+// upstream branch that has since been deleted (e.g. "foo") will block any
+// future fetch of a new nested branch under the same name ("foo/bar"). Git
+// cannot have a file and a directory at the same path under refs/remotes/origin,
+// and the fetch fails with "unable to update local ref". Pruning removes the
+// stale parent ref before writing the nested one.
 func (g *GitClient) FetchOrigin() error {
 	log.Info("📋 Starting to fetch from origin")
-	cmd := exec.Command("git", "fetch", "origin")
+	cmd := exec.Command("git", "fetch", "--prune", "origin")
 	g.setWorkDir(cmd)
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/clients/git_test.go
+++ b/clients/git_test.go
@@ -718,3 +718,142 @@ func TestWorktreeGitOperations(t *testing.T) {
 		t.Error("Expected uncommitted changes after modifying file")
 	}
 }
+
+
+// setupTestGitRepoWithBareOrigin creates a working clone of a bare origin repo
+// for testing FetchOrigin behavior. Returns the clone path, a helper to run
+// commands inside the bare origin, and a cleanup function.
+func setupTestGitRepoWithBareOrigin(t *testing.T) (clonePath string, originGit func(args ...string) (string, error), cleanup func()) {
+	t.Helper()
+
+	originDir, err := os.MkdirTemp("", "git-origin-bare-*")
+	if err != nil {
+		t.Fatalf("Failed to create origin temp dir: %v", err)
+	}
+
+	if out, err := exec.Command("git", "init", "--bare", "--initial-branch=main", originDir).CombinedOutput(); err != nil {
+		_ = os.RemoveAll(originDir)
+		t.Fatalf("Failed to init bare origin: %v\nOutput: %s", err, string(out))
+	}
+
+	// Seed the bare origin with an initial commit on main via a throwaway clone.
+	seedDir, err := os.MkdirTemp("", "git-seed-*")
+	if err != nil {
+		_ = os.RemoveAll(originDir)
+		t.Fatalf("Failed to create seed temp dir: %v", err)
+	}
+	runIn := func(dir string, args ...string) error {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("git %s in %s: %w\n%s", strings.Join(args, " "), dir, err, string(out))
+		}
+		return nil
+	}
+	if err := runIn("", "clone", originDir, seedDir); err != nil {
+		_ = os.RemoveAll(originDir)
+		_ = os.RemoveAll(seedDir)
+		t.Fatalf("Failed to seed clone: %v", err)
+	}
+	for _, args := range [][]string{
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test User"},
+		{"checkout", "-b", "main"},
+		{"commit", "--allow-empty", "-m", "initial"},
+		{"push", "-u", "origin", "main"},
+	} {
+		if err := runIn(seedDir, args...); err != nil {
+			_ = os.RemoveAll(originDir)
+			_ = os.RemoveAll(seedDir)
+			t.Fatalf("Seed setup failed: %v", err)
+		}
+	}
+	_ = os.RemoveAll(seedDir)
+
+	cloneDir, err := os.MkdirTemp("", "git-clone-*")
+	if err != nil {
+		_ = os.RemoveAll(originDir)
+		t.Fatalf("Failed to create clone temp dir: %v", err)
+	}
+	if err := runIn("", "clone", originDir, cloneDir); err != nil {
+		_ = os.RemoveAll(originDir)
+		_ = os.RemoveAll(cloneDir)
+		t.Fatalf("Failed to clone: %v", err)
+	}
+	for _, args := range [][]string{
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test User"},
+	} {
+		if err := runIn(cloneDir, args...); err != nil {
+			_ = os.RemoveAll(originDir)
+			_ = os.RemoveAll(cloneDir)
+			t.Fatalf("Clone config failed: %v", err)
+		}
+	}
+
+	originGit = func(args ...string) (string, error) {
+		full := append([]string{"--git-dir=" + originDir}, args...)
+		cmd := exec.Command("git", full...)
+		out, err := cmd.CombinedOutput()
+		return string(out), err
+	}
+
+	cleanup = func() {
+		_ = os.RemoveAll(cloneDir)
+		_ = os.RemoveAll(originDir)
+	}
+
+	return cloneDir, originGit, cleanup
+}
+
+// TestFetchOrigin_PrunesStaleRefsOnDFConflict reproduces the production bug
+// where a stale local remote-tracking ref blocks fetching a new nested branch
+// under the same path. Without --prune, git refuses the fetch with
+// "unable to update local ref" because it cannot have both a file and a
+// directory at the same path under refs/remotes/origin. With --prune, the
+// stale parent ref is removed before the nested ref is written.
+func TestFetchOrigin_PrunesStaleRefsOnDFConflict(t *testing.T) {
+	clonePath, originGit, cleanup := setupTestGitRepoWithBareOrigin(t)
+	defer cleanup()
+
+	mainSHAOut, err := originGit("rev-parse", "refs/heads/main")
+	if err != nil {
+		t.Fatalf("Failed to get main SHA on origin: %v", err)
+	}
+	mainSHA := strings.TrimSpace(mainSHAOut)
+
+	if _, err := originGit("update-ref", "refs/heads/mark-flaky", mainSHA); err != nil {
+		t.Fatalf("Failed to create mark-flaky on origin: %v", err)
+	}
+
+	client := NewGitClient()
+	client.SetRepoPathProvider(func() string { return clonePath })
+
+	if err := client.FetchOrigin(); err != nil {
+		t.Fatalf("Initial fetch should succeed: %v", err)
+	}
+
+	if out, err := exec.Command("git", "-C", clonePath, "rev-parse", "refs/remotes/origin/mark-flaky").CombinedOutput(); err != nil {
+		t.Fatalf("Expected refs/remotes/origin/mark-flaky to exist after first fetch, got error: %v\n%s", err, string(out))
+	}
+
+	if _, err := originGit("update-ref", "-d", "refs/heads/mark-flaky"); err != nil {
+		t.Fatalf("Failed to delete mark-flaky on origin: %v", err)
+	}
+	if _, err := originGit("update-ref", "refs/heads/mark-flaky/customer-book-and-repeat", mainSHA); err != nil {
+		t.Fatalf("Failed to create nested branch on origin: %v", err)
+	}
+
+	if err := client.FetchOrigin(); err != nil {
+		t.Fatalf("FetchOrigin should prune stale parent ref and succeed, got: %v", err)
+	}
+
+	if out, err := exec.Command("git", "-C", clonePath, "rev-parse", "refs/remotes/origin/mark-flaky").CombinedOutput(); err == nil {
+		t.Errorf("Expected stale refs/remotes/origin/mark-flaky to be pruned, but rev-parse succeeded: %s", string(out))
+	}
+
+	if out, err := exec.Command("git", "-C", clonePath, "rev-parse", "refs/remotes/origin/mark-flaky/customer-book-and-repeat").CombinedOutput(); err != nil {
+		t.Fatalf("Expected nested ref to be fetched, got error: %v\n%s", err, string(out))
+	}
+}


### PR DESCRIPTION
## Summary

`GitClient.FetchOrigin()` previously ran plain `git fetch origin`. When an upstream branch (e.g. `foo`) is deleted on GitHub and a new nested branch is later created at a path under the same name (e.g. `foo/bar`), the next fetch fails with:

```
error: cannot lock ref 'refs/remotes/origin/foo/bar': 'refs/remotes/origin/foo' exists; cannot create 'refs/remotes/origin/foo/bar'
 ! [new branch]  foo/bar -> origin/foo/bar  (unable to update local ref)
error: some local refs could not be updated; try running
 'git remote prune origin' to remove any old, conflicting branches
```

Git can't have both a file (`refs/remotes/origin/foo`) and a directory (`refs/remotes/origin/foo/...`) at the same path. The stale parent ref blocks the fetch, and since `FetchOrigin` is called by every worktree-pool replenish and every synchronous worktree creation, the entire agent gets stuck on "failed to prepare Git environment" for every new conversation until someone manually prunes the stale ref inside the container.

## Fix

Pass `--prune` to `git fetch origin`. With prune, git removes the stale `refs/remotes/origin/foo` before writing the nested `refs/remotes/origin/foo/bar`, and the fetch succeeds. `--prune` only deletes remote-tracking refs whose upstream branches no longer exist — it does not touch local branches, working trees, worktrees, commits, or anything on the actual remote.

The added doc comment explains the why so it doesn't accidentally get reverted later.

## Test plan

- [x] New regression test `TestFetchOrigin_PrunesStaleRefsOnDFConflict` in `clients/git_test.go` sets up a bare origin + a working clone, creates branch `mark-flaky`, fetches it (creating the stale local ref), deletes it upstream, creates nested `mark-flaky/customer-book-and-repeat`, then calls `FetchOrigin` and verifies (a) it succeeds, (b) the stale parent ref is pruned, (c) the new nested ref is fetched.
- [x] Confirmed the test fails (with the exact production error) when the `--prune` flag is removed, and passes when it's in place.
- [x] Full `clients/` test suite passes.
- [x] Full `usecases/` test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)