### PR TITLE
feat: emit per-message cost on assistant messages

### DIFF
--- a/handlers/messages.go
+++ b/handlers/messages.go
@@ -444,6 +444,7 @@ func (mh *MessageHandler) handleStartConversation(msg models.BaseMessage) error 
 		ProcessedMessageID: payload.ProcessedMessageID,
 		AttachmentIDs:      attachmentIDs,
 	}
+	applyUsageToAssistantPayload(&assistantPayload, claudeResult.Usage)
 
 	assistantMsg := models.BaseMessage{
 		ID:      core.NewID("msg"),
@@ -835,6 +836,7 @@ func (mh *MessageHandler) handleUserMessage(msg models.BaseMessage) error {
 		ProcessedMessageID: payload.ProcessedMessageID,
 		AttachmentIDs:      outboundAttachmentIDs,
 	}
+	applyUsageToAssistantPayload(&assistantPayload, claudeResult.Usage)
 
 	assistantMsg := models.BaseMessage{
 		ID:      core.NewID("msg"),

--- a/handlers/messages_cost.go
+++ b/handlers/messages_cost.go
@@ -1,0 +1,26 @@
+package handlers
+
+import (
+	"nairid/models"
+	"nairid/services"
+)
+
+// applyUsageToAssistantPayload copies optional cost / token fields from a
+// CLIAgentResult.Usage onto an outgoing AssistantMessagePayload so the
+// backend can persist them on the conversation_messages row. Nil-safe:
+// when usage is nil (e.g. Cursor, or extraction failure) the payload is
+// left as-is and the backend stores NULL for every cost column.
+func applyUsageToAssistantPayload(p *models.AssistantMessagePayload, usage *services.CLIAgentUsage) {
+	if p == nil || usage == nil {
+		return
+	}
+	p.CostUSD = usage.CostUSD
+	p.InputTokens = usage.InputTokens
+	p.OutputTokens = usage.OutputTokens
+	p.CacheReadTokens = usage.CacheReadTokens
+	p.CacheWriteTokens = usage.CacheWriteTokens
+	if usage.Model != "" {
+		m := usage.Model
+		p.Model = &m
+	}
+}

--- a/handlers/messages_cost.go
+++ b/handlers/messages_cost.go
@@ -19,8 +19,5 @@ func applyUsageToAssistantPayload(p *models.AssistantMessagePayload, usage *serv
 	p.OutputTokens = usage.OutputTokens
 	p.CacheReadTokens = usage.CacheReadTokens
 	p.CacheWriteTokens = usage.CacheWriteTokens
-	if usage.Model != "" {
-		m := usage.Model
-		p.Model = &m
-	}
+	p.Model = usage.Model
 }

--- a/handlers/messages_cost_test.go
+++ b/handlers/messages_cost_test.go
@@ -9,6 +9,7 @@ import (
 
 func ptrFloat(v float64) *float64 { return &v }
 func ptrI64(v int64) *int64       { return &v }
+func ptrStr(v string) *string     { return &v }
 
 func TestApplyUsageToAssistantPayload_NilUsageLeavesFieldsNil(t *testing.T) {
 	p := &models.AssistantMessagePayload{
@@ -34,7 +35,7 @@ func TestApplyUsageToAssistantPayload_PopulatesAllFields(t *testing.T) {
 		OutputTokens:     ptrI64(23),
 		CacheReadTokens:  ptrI64(1792),
 		CacheWriteTokens: ptrI64(0),
-		Model:            "claude-sonnet-4-5-20250929",
+		Model:            ptrStr("claude-sonnet-4-5-20250929"),
 	}
 	p := &models.AssistantMessagePayload{JobID: "j", Message: "m"}
 	applyUsageToAssistantPayload(p, usage)
@@ -58,14 +59,13 @@ func TestApplyUsageToAssistantPayload_PopulatesAllFields(t *testing.T) {
 	}
 }
 
-func TestApplyUsageToAssistantPayload_EmptyModelStaysNil(t *testing.T) {
-	// Usage with cost but no model name should not produce a non-nil Model
-	// pointer to the empty string in the outgoing payload.
+func TestApplyUsageToAssistantPayload_NilModelStaysNil(t *testing.T) {
+	// Usage with cost but no model name should propagate as a nil Model.
 	usage := &services.CLIAgentUsage{CostUSD: ptrFloat(0.05)}
 	p := &models.AssistantMessagePayload{}
 	applyUsageToAssistantPayload(p, usage)
 	if p.Model != nil {
-		t.Fatalf("expected nil Model for empty usage.Model, got %v", p.Model)
+		t.Fatalf("expected nil Model when usage.Model is nil, got %v", p.Model)
 	}
 	if p.CostUSD == nil || *p.CostUSD != 0.05 {
 		t.Fatalf("CostUSD not propagated: %v", p.CostUSD)

--- a/handlers/messages_cost_test.go
+++ b/handlers/messages_cost_test.go
@@ -1,0 +1,73 @@
+package handlers
+
+import (
+	"testing"
+
+	"nairid/models"
+	"nairid/services"
+)
+
+func ptrFloat(v float64) *float64 { return &v }
+func ptrI64(v int64) *int64       { return &v }
+
+func TestApplyUsageToAssistantPayload_NilUsageLeavesFieldsNil(t *testing.T) {
+	p := &models.AssistantMessagePayload{
+		JobID:   "job_1",
+		Message: "hi",
+	}
+	applyUsageToAssistantPayload(p, nil)
+	if p.CostUSD != nil || p.InputTokens != nil || p.OutputTokens != nil ||
+		p.CacheReadTokens != nil || p.CacheWriteTokens != nil || p.Model != nil {
+		t.Fatalf("expected all cost fields nil for nil usage, got %+v", p)
+	}
+}
+
+func TestApplyUsageToAssistantPayload_NilPayloadIsNoOp(t *testing.T) {
+	// Should not panic.
+	applyUsageToAssistantPayload(nil, &services.CLIAgentUsage{CostUSD: ptrFloat(0.01)})
+}
+
+func TestApplyUsageToAssistantPayload_PopulatesAllFields(t *testing.T) {
+	usage := &services.CLIAgentUsage{
+		CostUSD:          ptrFloat(0.0283605),
+		InputTokens:      ptrI64(21744),
+		OutputTokens:     ptrI64(23),
+		CacheReadTokens:  ptrI64(1792),
+		CacheWriteTokens: ptrI64(0),
+		Model:            "claude-sonnet-4-5-20250929",
+	}
+	p := &models.AssistantMessagePayload{JobID: "j", Message: "m"}
+	applyUsageToAssistantPayload(p, usage)
+	if p.CostUSD == nil || *p.CostUSD != 0.0283605 {
+		t.Fatalf("CostUSD not propagated: %v", p.CostUSD)
+	}
+	if p.InputTokens == nil || *p.InputTokens != 21744 {
+		t.Fatalf("InputTokens not propagated: %v", p.InputTokens)
+	}
+	if p.OutputTokens == nil || *p.OutputTokens != 23 {
+		t.Fatalf("OutputTokens not propagated: %v", p.OutputTokens)
+	}
+	if p.CacheReadTokens == nil || *p.CacheReadTokens != 1792 {
+		t.Fatalf("CacheReadTokens not propagated: %v", p.CacheReadTokens)
+	}
+	if p.CacheWriteTokens == nil || *p.CacheWriteTokens != 0 {
+		t.Fatalf("CacheWriteTokens not propagated: %v", p.CacheWriteTokens)
+	}
+	if p.Model == nil || *p.Model != "claude-sonnet-4-5-20250929" {
+		t.Fatalf("Model not propagated: %v", p.Model)
+	}
+}
+
+func TestApplyUsageToAssistantPayload_EmptyModelStaysNil(t *testing.T) {
+	// Usage with cost but no model name should not produce a non-nil Model
+	// pointer to the empty string in the outgoing payload.
+	usage := &services.CLIAgentUsage{CostUSD: ptrFloat(0.05)}
+	p := &models.AssistantMessagePayload{}
+	applyUsageToAssistantPayload(p, usage)
+	if p.Model != nil {
+		t.Fatalf("expected nil Model for empty usage.Model, got %v", p.Model)
+	}
+	if p.CostUSD == nil || *p.CostUSD != 0.05 {
+		t.Fatalf("CostUSD not propagated: %v", p.CostUSD)
+	}
+}

--- a/models/messages.go
+++ b/models/messages.go
@@ -132,6 +132,15 @@ type AssistantMessagePayload struct {
 	Message            string   `json:"message"`
 	ProcessedMessageID string   `json:"processed_message_id"`
 	AttachmentIDs      []string `json:"attachment_ids,omitempty"`
+	// Optional cost and token usage reported by the harness.
+	// Cursor leaves all of these nil; Claude/Codex/OpenCode populate
+	// what they know after the turn completes.
+	CostUSD          *float64 `json:"cost_usd,omitempty"`
+	InputTokens      *int64   `json:"input_tokens,omitempty"`
+	OutputTokens     *int64   `json:"output_tokens,omitempty"`
+	CacheReadTokens  *int64   `json:"cache_read_tokens,omitempty"`
+	CacheWriteTokens *int64   `json:"cache_write_tokens,omitempty"`
+	Model            *string  `json:"model,omitempty"`
 }
 
 type SystemMessagePayload struct {

--- a/services/claude/claude.go
+++ b/services/claude/claude.go
@@ -199,6 +199,7 @@ func (c *ClaudeService) StartNewConversationWithOptions(
 	result := &services.CLIAgentResult{
 		Output:    output,
 		SessionID: sessionID,
+		Usage:     extractClaudeUsage(messages),
 	}
 
 	log.Info("📋 Completed successfully - started new Claude conversation with session: %s", sessionID)
@@ -332,6 +333,7 @@ func (c *ClaudeService) ContinueConversationWithOptions(
 	result := &services.CLIAgentResult{
 		Output:    output,
 		SessionID: actualSessionID,
+		Usage:     extractClaudeUsage(messages),
 	}
 
 	log.Info("📋 Completed successfully - continued Claude conversation with session: %s", actualSessionID)

--- a/services/claude/claude_test.go
+++ b/services/claude/claude_test.go
@@ -431,10 +431,12 @@ func TestClaudeService_extractSessionID(t *testing.T) {
 				services.AssistantMessage{
 					Type: "assistant",
 					Message: struct {
-						ID         string            `json:"id"`
-						Type       string            `json:"type"`
-						Content    []json.RawMessage `json:"content"`
-						StopReason string            `json:"stop_reason"`
+						ID         string               `json:"id"`
+						Type       string               `json:"type"`
+						Model      string               `json:"model,omitempty"`
+						Content    []json.RawMessage    `json:"content"`
+						StopReason string               `json:"stop_reason"`
+						Usage      services.ClaudeUsage `json:"usage"`
 					}{
 						ID:         "msg_123",
 						Type:       "message",
@@ -471,10 +473,12 @@ func TestClaudeService_extractSessionID(t *testing.T) {
 				services.AssistantMessage{
 					Type: "assistant",
 					Message: struct {
-						ID         string            `json:"id"`
-						Type       string            `json:"type"`
-						Content    []json.RawMessage `json:"content"`
-						StopReason string            `json:"stop_reason"`
+						ID         string               `json:"id"`
+						Type       string               `json:"type"`
+						Model      string               `json:"model,omitempty"`
+						Content    []json.RawMessage    `json:"content"`
+						StopReason string               `json:"stop_reason"`
+						Usage      services.ClaudeUsage `json:"usage"`
 					}{
 						ID:      "msg_456",
 						Type:    "message",
@@ -527,10 +531,12 @@ func TestClaudeService_extractClaudeResult(t *testing.T) {
 				services.AssistantMessage{
 					Type: "assistant",
 					Message: struct {
-						ID         string            `json:"id"`
-						Type       string            `json:"type"`
-						Content    []json.RawMessage `json:"content"`
-						StopReason string            `json:"stop_reason"`
+						ID         string               `json:"id"`
+						Type       string               `json:"type"`
+						Model      string               `json:"model,omitempty"`
+						Content    []json.RawMessage    `json:"content"`
+						StopReason string               `json:"stop_reason"`
+						Usage      services.ClaudeUsage `json:"usage"`
 					}{
 						ID:         "msg_123",
 						Type:       "message",
@@ -551,10 +557,12 @@ func TestClaudeService_extractClaudeResult(t *testing.T) {
 				services.AssistantMessage{
 					Type: "assistant",
 					Message: struct {
-						ID         string            `json:"id"`
-						Type       string            `json:"type"`
-						Content    []json.RawMessage `json:"content"`
-						StopReason string            `json:"stop_reason"`
+						ID         string               `json:"id"`
+						Type       string               `json:"type"`
+						Model      string               `json:"model,omitempty"`
+						Content    []json.RawMessage    `json:"content"`
+						StopReason string               `json:"stop_reason"`
+						Usage      services.ClaudeUsage `json:"usage"`
 					}{
 						ID:         "msg_123",
 						Type:       "message",
@@ -586,10 +594,12 @@ func TestClaudeService_extractClaudeResult(t *testing.T) {
 				services.AssistantMessage{
 					Type: "assistant",
 					Message: struct {
-						ID         string            `json:"id"`
-						Type       string            `json:"type"`
-						Content    []json.RawMessage `json:"content"`
-						StopReason string            `json:"stop_reason"`
+						ID         string               `json:"id"`
+						Type       string               `json:"type"`
+						Model      string               `json:"model,omitempty"`
+						Content    []json.RawMessage    `json:"content"`
+						StopReason string               `json:"stop_reason"`
+						Usage      services.ClaudeUsage `json:"usage"`
 					}{
 						ID:         "msg_only",
 						Type:       "message",
@@ -622,10 +632,12 @@ func TestClaudeService_extractClaudeResult(t *testing.T) {
 				services.AssistantMessage{
 					Type: "assistant",
 					Message: struct {
-						ID         string            `json:"id"`
-						Type       string            `json:"type"`
-						Content    []json.RawMessage `json:"content"`
-						StopReason string            `json:"stop_reason"`
+						ID         string               `json:"id"`
+						Type       string               `json:"type"`
+						Model      string               `json:"model,omitempty"`
+						Content    []json.RawMessage    `json:"content"`
+						StopReason string               `json:"stop_reason"`
+						Usage      services.ClaudeUsage `json:"usage"`
 					}{
 						ID:         "msg_detailed",
 						Type:       "message",
@@ -652,10 +664,12 @@ func TestClaudeService_extractClaudeResult(t *testing.T) {
 				services.AssistantMessage{
 					Type: "assistant",
 					Message: struct {
-						ID         string            `json:"id"`
-						Type       string            `json:"type"`
-						Content    []json.RawMessage `json:"content"`
-						StopReason string            `json:"stop_reason"`
+						ID         string               `json:"id"`
+						Type       string               `json:"type"`
+						Model      string               `json:"model,omitempty"`
+						Content    []json.RawMessage    `json:"content"`
+						StopReason string               `json:"stop_reason"`
+						Usage      services.ClaudeUsage `json:"usage"`
 					}{
 						ID:         "msg_confirm",
 						Type:       "message",
@@ -690,10 +704,12 @@ func TestClaudeService_extractClaudeResult(t *testing.T) {
 				services.AssistantMessage{
 					Type: "assistant",
 					Message: struct {
-						ID         string            `json:"id"`
-						Type       string            `json:"type"`
-						Content    []json.RawMessage `json:"content"`
-						StopReason string            `json:"stop_reason"`
+						ID         string               `json:"id"`
+						Type       string               `json:"type"`
+						Model      string               `json:"model,omitempty"`
+						Content    []json.RawMessage    `json:"content"`
+						StopReason string               `json:"stop_reason"`
+						Usage      services.ClaudeUsage `json:"usage"`
 					}{
 						ID:         "msg_analysis",
 						Type:       "message",
@@ -720,10 +736,12 @@ func TestClaudeService_extractClaudeResult(t *testing.T) {
 				services.AssistantMessage{
 					Type: "assistant",
 					Message: struct {
-						ID         string            `json:"id"`
-						Type       string            `json:"type"`
-						Content    []json.RawMessage `json:"content"`
-						StopReason string            `json:"stop_reason"`
+						ID         string               `json:"id"`
+						Type       string               `json:"type"`
+						Model      string               `json:"model,omitempty"`
+						Content    []json.RawMessage    `json:"content"`
+						StopReason string               `json:"stop_reason"`
+						Usage      services.ClaudeUsage `json:"usage"`
 					}{
 						ID:         "msg_summary",
 						Type:       "message",
@@ -747,10 +765,12 @@ func TestClaudeService_extractClaudeResult(t *testing.T) {
 				services.AssistantMessage{
 					Type: "assistant",
 					Message: struct {
-						ID         string            `json:"id"`
-						Type       string            `json:"type"`
-						Content    []json.RawMessage `json:"content"`
-						StopReason string            `json:"stop_reason"`
+						ID         string               `json:"id"`
+						Type       string               `json:"type"`
+						Model      string               `json:"model,omitempty"`
+						Content    []json.RawMessage    `json:"content"`
+						StopReason string               `json:"stop_reason"`
+						Usage      services.ClaudeUsage `json:"usage"`
 					}{
 						ID:         "msg_poem",
 						Type:       "message",
@@ -777,10 +797,12 @@ func TestClaudeService_extractClaudeResult(t *testing.T) {
 				services.AssistantMessage{
 					Type: "assistant",
 					Message: struct {
-						ID         string            `json:"id"`
-						Type       string            `json:"type"`
-						Content    []json.RawMessage `json:"content"`
-						StopReason string            `json:"stop_reason"`
+						ID         string               `json:"id"`
+						Type       string               `json:"type"`
+						Model      string               `json:"model,omitempty"`
+						Content    []json.RawMessage    `json:"content"`
+						StopReason string               `json:"stop_reason"`
+						Usage      services.ClaudeUsage `json:"usage"`
 					}{
 						ID:         "msg_haiku",
 						Type:       "message",

--- a/services/claude/cost.go
+++ b/services/claude/cost.go
@@ -1,0 +1,85 @@
+package claude
+
+import (
+	"nairid/services"
+)
+
+// extractClaudeUsage builds a CLIAgentUsage from a stream of Claude messages.
+// It pulls per-LLM-call token counts from "assistant" events (summed across
+// the whole session) and pulls total_cost_usd from the final "result" event
+// when present. Cache reads and cache creation are tracked separately to
+// preserve granularity in the API.
+//
+// Returns nil if no usage data is found, so the caller can leave cost fields
+// nil upstream rather than persisting zeros that would misleadingly imply
+// a free call.
+func extractClaudeUsage(messages []services.ClaudeMessage) *services.CLIAgentUsage {
+	var (
+		inputTokens  int64
+		outputTokens int64
+		cacheRead    int64
+		cacheCreate  int64
+		hasUsage     bool
+
+		costUSD    float64
+		hasCostUSD bool
+
+		model string
+	)
+
+	for _, msg := range messages {
+		switch m := msg.(type) {
+		case services.AssistantMessage:
+			u := m.Message.Usage
+			if u.InputTokens > 0 || u.OutputTokens > 0 ||
+				u.CacheReadInputTokens > 0 || u.CacheCreationInputTokens > 0 {
+				hasUsage = true
+				inputTokens += u.InputTokens
+				outputTokens += u.OutputTokens
+				cacheRead += u.CacheReadInputTokens
+				cacheCreate += u.CacheCreationInputTokens
+			}
+			if model == "" && m.Message.Model != "" {
+				model = m.Message.Model
+			}
+		case services.ResultMessage:
+			if m.TotalCostUsd > 0 {
+				costUSD = m.TotalCostUsd
+				hasCostUSD = true
+			}
+			// ResultMessage usage is the per-session rollup. Prefer it over
+			// the per-call sum when present, since it accounts for cases the
+			// stream parser might have missed.
+			u := m.Usage
+			if u.InputTokens > 0 || u.OutputTokens > 0 ||
+				u.CacheReadInputTokens > 0 || u.CacheCreationInputTokens > 0 {
+				hasUsage = true
+				inputTokens = u.InputTokens
+				outputTokens = u.OutputTokens
+				cacheRead = u.CacheReadInputTokens
+				cacheCreate = u.CacheCreationInputTokens
+			}
+		}
+	}
+
+	if !hasUsage && !hasCostUSD {
+		return nil
+	}
+
+	usage := &services.CLIAgentUsage{Model: model}
+	if hasCostUSD {
+		c := costUSD
+		usage.CostUSD = &c
+	}
+	if hasUsage {
+		in := inputTokens
+		out := outputTokens
+		cr := cacheRead
+		cw := cacheCreate
+		usage.InputTokens = &in
+		usage.OutputTokens = &out
+		usage.CacheReadTokens = &cr
+		usage.CacheWriteTokens = &cw
+	}
+	return usage
+}

--- a/services/claude/cost.go
+++ b/services/claude/cost.go
@@ -66,7 +66,11 @@ func extractClaudeUsage(messages []services.ClaudeMessage) *services.CLIAgentUsa
 		return nil
 	}
 
-	usage := &services.CLIAgentUsage{Model: model}
+	usage := &services.CLIAgentUsage{}
+	if model != "" {
+		m := model
+		usage.Model = &m
+	}
 	if hasCostUSD {
 		c := costUSD
 		usage.CostUSD = &c

--- a/services/claude/cost_test.go
+++ b/services/claude/cost_test.go
@@ -66,8 +66,8 @@ func TestExtractClaudeUsage_AssistantOnly_SumsAcrossCalls(t *testing.T) {
 	if got.CacheWriteTokens == nil || *got.CacheWriteTokens != 100 {
 		t.Fatalf("CacheWriteTokens want 100, got %v", got.CacheWriteTokens)
 	}
-	if got.Model != "claude-sonnet-4-5-20250929" {
-		t.Fatalf("Model = %q, want claude-sonnet-4-5-20250929", got.Model)
+	if got.Model == nil || *got.Model != "claude-sonnet-4-5-20250929" {
+		t.Fatalf("Model = %v, want claude-sonnet-4-5-20250929", got.Model)
 	}
 }
 

--- a/services/claude/cost_test.go
+++ b/services/claude/cost_test.go
@@ -1,0 +1,117 @@
+package claude
+
+import (
+	"encoding/json"
+	"testing"
+
+	"nairid/services"
+)
+
+func newAssistant(input, output, cacheRead, cacheWrite int64, model string) services.AssistantMessage {
+	var a services.AssistantMessage
+	a.Type = "assistant"
+	a.SessionID = "session_test"
+	a.Message.ID = "msg_assist"
+	a.Message.Type = "message"
+	a.Message.Model = model
+	a.Message.Content = []json.RawMessage{}
+	a.Message.StopReason = "end_turn"
+	a.Message.Usage = services.ClaudeUsage{
+		InputTokens:              input,
+		OutputTokens:             output,
+		CacheReadInputTokens:     cacheRead,
+		CacheCreationInputTokens: cacheWrite,
+	}
+	return a
+}
+
+func newResult(costUSD float64) services.ResultMessage {
+	return services.ResultMessage{
+		Type:         "result",
+		Subtype:      "success",
+		IsError:      false,
+		Result:       "all done",
+		SessionID:    "session_test",
+		TotalCostUsd: costUSD,
+	}
+}
+
+func TestExtractClaudeUsage_NoMessages(t *testing.T) {
+	if got := extractClaudeUsage(nil); got != nil {
+		t.Fatalf("expected nil usage from empty messages, got %+v", got)
+	}
+}
+
+func TestExtractClaudeUsage_AssistantOnly_SumsAcrossCalls(t *testing.T) {
+	msgs := []services.ClaudeMessage{
+		newAssistant(100, 50, 200, 0, "claude-sonnet-4-5-20250929"),
+		newAssistant(10, 5, 50, 100, "claude-sonnet-4-5-20250929"),
+	}
+	got := extractClaudeUsage(msgs)
+	if got == nil {
+		t.Fatal("expected non-nil usage")
+	}
+	if got.CostUSD != nil {
+		t.Fatalf("expected nil cost without ResultMessage, got %v", *got.CostUSD)
+	}
+	if got.InputTokens == nil || *got.InputTokens != 110 {
+		t.Fatalf("InputTokens want 110, got %v", got.InputTokens)
+	}
+	if got.OutputTokens == nil || *got.OutputTokens != 55 {
+		t.Fatalf("OutputTokens want 55, got %v", got.OutputTokens)
+	}
+	if got.CacheReadTokens == nil || *got.CacheReadTokens != 250 {
+		t.Fatalf("CacheReadTokens want 250, got %v", got.CacheReadTokens)
+	}
+	if got.CacheWriteTokens == nil || *got.CacheWriteTokens != 100 {
+		t.Fatalf("CacheWriteTokens want 100, got %v", got.CacheWriteTokens)
+	}
+	if got.Model != "claude-sonnet-4-5-20250929" {
+		t.Fatalf("Model = %q, want claude-sonnet-4-5-20250929", got.Model)
+	}
+}
+
+func TestExtractClaudeUsage_ResultUsagePreferred(t *testing.T) {
+	// When a ResultMessage carries its own usage rollup it wins over the
+	// per-assistant-event sum.
+	msgs := []services.ClaudeMessage{
+		newAssistant(100, 50, 200, 0, "claude-sonnet-4-5-20250929"),
+		func() services.ResultMessage {
+			r := newResult(0.045)
+			r.Usage = services.ClaudeUsage{
+				InputTokens:              999,
+				OutputTokens:             888,
+				CacheReadInputTokens:     777,
+				CacheCreationInputTokens: 666,
+			}
+			return r
+		}(),
+	}
+	got := extractClaudeUsage(msgs)
+	if got == nil {
+		t.Fatal("expected non-nil usage")
+	}
+	if got.CostUSD == nil || *got.CostUSD != 0.045 {
+		t.Fatalf("CostUSD = %v, want 0.045", got.CostUSD)
+	}
+	if *got.InputTokens != 999 || *got.OutputTokens != 888 ||
+		*got.CacheReadTokens != 777 || *got.CacheWriteTokens != 666 {
+		t.Fatalf("ResultMessage usage was not preferred: %+v", got)
+	}
+}
+
+func TestExtractClaudeUsage_ResultCostOnly_NoTokens(t *testing.T) {
+	// ResultMessage with cost but no usage rollup, no assistant events with tokens —
+	// only cost is exposed.
+	msgs := []services.ClaudeMessage{newResult(0.123)}
+	got := extractClaudeUsage(msgs)
+	if got == nil {
+		t.Fatal("expected non-nil usage")
+	}
+	if got.CostUSD == nil || *got.CostUSD != 0.123 {
+		t.Fatalf("CostUSD = %v, want 0.123", got.CostUSD)
+	}
+	if got.InputTokens != nil || got.OutputTokens != nil {
+		t.Fatalf("expected nil token counts, got input=%v output=%v", got.InputTokens, got.OutputTokens)
+	}
+}

--- a/services/claude_messages.go
+++ b/services/claude_messages.go
@@ -13,14 +13,26 @@ type ClaudeMessage interface {
 	GetSessionID() string
 }
 
+// ClaudeUsage holds per-LLM-call token accounting emitted on every "assistant"
+// event in claude --output-format stream-json. Cache fields are zero when the
+// API call did not use the prompt cache.
+type ClaudeUsage struct {
+	InputTokens              int64 `json:"input_tokens"`
+	OutputTokens             int64 `json:"output_tokens"`
+	CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+}
+
 // AssistantMessage represents an assistant message from Claude
 type AssistantMessage struct {
 	Type    string `json:"type"`
 	Message struct {
 		ID         string            `json:"id"`
 		Type       string            `json:"type"`
+		Model      string            `json:"model,omitempty"`
 		Content    []json.RawMessage `json:"content"`     // Use RawMessage to handle both text and tool_use content
 		StopReason string            `json:"stop_reason"` // "end_turn" means final response, "tool_use" means more actions coming
+		Usage      ClaudeUsage       `json:"usage"`
 	} `json:"message"`
 	SessionID string `json:"session_id"`
 }
@@ -82,15 +94,16 @@ func (u UserMessage) GetSessionID() string {
 
 // ResultMessage represents a result message from Claude
 type ResultMessage struct {
-	Type          string  `json:"type"`
-	Subtype       string  `json:"subtype"`
-	IsError       bool    `json:"is_error"`
-	DurationMs    int     `json:"duration_ms"`
-	DurationAPIMs int     `json:"duration_api_ms"`
-	NumTurns      int     `json:"num_turns"`
-	Result        string  `json:"result"`
-	SessionID     string  `json:"session_id"`
-	TotalCostUsd  float64 `json:"total_cost_usd"`
+	Type          string      `json:"type"`
+	Subtype       string      `json:"subtype"`
+	IsError       bool        `json:"is_error"`
+	DurationMs    int         `json:"duration_ms"`
+	DurationAPIMs int         `json:"duration_api_ms"`
+	NumTurns      int         `json:"num_turns"`
+	Result        string      `json:"result"`
+	SessionID     string      `json:"session_id"`
+	TotalCostUsd  float64     `json:"total_cost_usd"`
+	Usage         ClaudeUsage `json:"usage"`
 }
 
 func (r ResultMessage) GetType() string {

--- a/services/codex/codex.go
+++ b/services/codex/codex.go
@@ -169,10 +169,21 @@ func (c *CodexService) StartNewConversationWithOptions(
 	result := &services.CLIAgentResult{
 		Output:    output,
 		SessionID: threadID,
+		Usage:     extractCodexUsage(messages, c.effectiveModel(finalOptions)),
 	}
 
 	log.Info("📋 Completed successfully - started new Codex conversation with thread: %s", threadID)
 	return result, nil
+}
+
+// effectiveModel returns the model id used for the just-completed Codex
+// session, preferring the per-call options override and falling back to
+// the service-level default. Returns empty string if neither is set.
+func (c *CodexService) effectiveModel(opts *clients.CodexOptions) string {
+	if opts != nil && opts.Model != "" {
+		return opts.Model
+	}
+	return c.model
 }
 
 func (c *CodexService) StartNewConversationWithSystemPrompt(
@@ -287,6 +298,7 @@ func (c *CodexService) ContinueConversationWithOptions(
 	result := &services.CLIAgentResult{
 		Output:    output,
 		SessionID: actualThreadID,
+		Usage:     extractCodexUsage(messages, c.effectiveModel(finalOptions)),
 	}
 
 	log.Info("📋 Completed successfully - continued Codex conversation with thread: %s", actualThreadID)

--- a/services/codex/cost.go
+++ b/services/codex/cost.go
@@ -51,10 +51,13 @@ func extractCodexUsage(messages []CodexMessage, model string) *services.CLIAgent
 	// nil to signal "unknown" rather than hardcoding 0, which would falsely
 	// imply we observed zero cache writes.
 	usage := &services.CLIAgentUsage{
-		Model:           model,
 		InputTokens:     &in,
 		OutputTokens:    &out,
 		CacheReadTokens: &cr,
+	}
+	if model != "" {
+		m := model
+		usage.Model = &m
 	}
 
 	if cost, ok := pricing.CodexCostUSD(model, inputTokens, cachedInputTokens, outputTokens); ok {

--- a/services/codex/cost.go
+++ b/services/codex/cost.go
@@ -46,16 +46,15 @@ func extractCodexUsage(messages []CodexMessage, model string) *services.CLIAgent
 	in := inputTokens
 	out := outputTokens
 	cr := cachedInputTokens
-	// Codex does not surface cache-write counts; the cached_input_tokens are
-	// cache reads only. We leave CacheWriteTokens at zero (explicit) so the
-	// shape matches Claude/OpenCode.
-	cw := int64(0)
+	// Codex's turn.completed events only report cached_input_tokens (= cache
+	// reads); the CLI does not surface cache-write counts. Leave CacheWriteTokens
+	// nil to signal "unknown" rather than hardcoding 0, which would falsely
+	// imply we observed zero cache writes.
 	usage := &services.CLIAgentUsage{
-		Model:            model,
-		InputTokens:      &in,
-		OutputTokens:     &out,
-		CacheReadTokens:  &cr,
-		CacheWriteTokens: &cw,
+		Model:           model,
+		InputTokens:     &in,
+		OutputTokens:    &out,
+		CacheReadTokens: &cr,
 	}
 
 	if cost, ok := pricing.CodexCostUSD(model, inputTokens, cachedInputTokens, outputTokens); ok {

--- a/services/codex/cost.go
+++ b/services/codex/cost.go
@@ -1,0 +1,67 @@
+package codex
+
+import (
+	"nairid/services"
+	"nairid/services/pricing"
+)
+
+// extractCodexUsage builds a CLIAgentUsage from a stream of Codex messages.
+//
+// Codex emits a turn.completed event after every LLM call inside a session
+// with a `usage` block (input_tokens, cached_input_tokens, output_tokens).
+// We sum across all turns to get session-level totals.
+//
+// Cost is computed via the local pricing table (nairid/services/pricing)
+// since the Codex CLI itself does not report a dollar cost. If the model is
+// unknown to the pricing table the usage is still returned but CostUSD stays nil.
+//
+// Returns nil if no turn.completed events were seen, so callers can leave
+// cost columns NULL upstream rather than persisting zeros.
+func extractCodexUsage(messages []CodexMessage, model string) *services.CLIAgentUsage {
+	var (
+		inputTokens       int64
+		cachedInputTokens int64
+		outputTokens      int64
+		seenAny           bool
+	)
+
+	for _, msg := range messages {
+		t, ok := msg.(TurnCompletedMessage)
+		if !ok {
+			continue
+		}
+		if t.Usage.InputTokens == 0 && t.Usage.CachedInputTokens == 0 && t.Usage.OutputTokens == 0 {
+			continue
+		}
+		seenAny = true
+		inputTokens += int64(t.Usage.InputTokens)
+		cachedInputTokens += int64(t.Usage.CachedInputTokens)
+		outputTokens += int64(t.Usage.OutputTokens)
+	}
+
+	if !seenAny {
+		return nil
+	}
+
+	in := inputTokens
+	out := outputTokens
+	cr := cachedInputTokens
+	// Codex does not surface cache-write counts; the cached_input_tokens are
+	// cache reads only. We leave CacheWriteTokens at zero (explicit) so the
+	// shape matches Claude/OpenCode.
+	cw := int64(0)
+	usage := &services.CLIAgentUsage{
+		Model:            model,
+		InputTokens:      &in,
+		OutputTokens:     &out,
+		CacheReadTokens:  &cr,
+		CacheWriteTokens: &cw,
+	}
+
+	if cost, ok := pricing.CodexCostUSD(model, inputTokens, cachedInputTokens, outputTokens); ok {
+		c := cost
+		usage.CostUSD = &c
+	}
+
+	return usage
+}

--- a/services/codex/cost_test.go
+++ b/services/codex/cost_test.go
@@ -1,0 +1,84 @@
+package codex
+
+import (
+	"math"
+	"testing"
+)
+
+func turn(input, cached, output int) TurnCompletedMessage {
+	var t TurnCompletedMessage
+	t.Type = "turn.completed"
+	t.Usage.InputTokens = input
+	t.Usage.CachedInputTokens = cached
+	t.Usage.OutputTokens = output
+	return t
+}
+
+func TestExtractCodexUsage_NoTurnMessages(t *testing.T) {
+	msgs := []CodexMessage{
+		ThreadStartedMessage{Type: "thread.started", ThreadID: "th_1"},
+		ItemCompletedMessage{Type: "item.completed"},
+	}
+	if got := extractCodexUsage(msgs, "gpt-5"); got != nil {
+		t.Fatalf("expected nil usage when no turn.completed events present, got %+v", got)
+	}
+}
+
+func TestExtractCodexUsage_SumsAcrossTurns(t *testing.T) {
+	msgs := []CodexMessage{
+		turn(1000, 500, 200),
+		turn(300, 100, 80),
+	}
+	got := extractCodexUsage(msgs, "gpt-5-codex")
+	if got == nil {
+		t.Fatal("expected non-nil usage")
+	}
+	if *got.InputTokens != 1300 {
+		t.Fatalf("InputTokens = %v, want 1300", *got.InputTokens)
+	}
+	if *got.OutputTokens != 280 {
+		t.Fatalf("OutputTokens = %v, want 280", *got.OutputTokens)
+	}
+	if *got.CacheReadTokens != 600 {
+		t.Fatalf("CacheReadTokens = %v, want 600", *got.CacheReadTokens)
+	}
+	if *got.CacheWriteTokens != 0 {
+		t.Fatalf("CacheWriteTokens should always be 0 for Codex, got %v", *got.CacheWriteTokens)
+	}
+	if got.Model != "gpt-5-codex" {
+		t.Fatalf("Model = %q, want gpt-5-codex", got.Model)
+	}
+	// Cost should be computable from gpt-5-codex pricing.
+	// fresh = 1300 - 600 = 700 → 700/1M * 1.25 = 0.000875
+	// cached = 600/1M * 0.125 = 0.000075
+	// output = 280/1M * 10.00 = 0.0028
+	// total = 0.00375
+	const wantCost = 0.000875 + 0.000075 + 0.0028
+	if got.CostUSD == nil || math.Abs(*got.CostUSD-wantCost) > 1e-9 {
+		t.Fatalf("CostUSD = %v, want %v", got.CostUSD, wantCost)
+	}
+}
+
+func TestExtractCodexUsage_UnknownModelLeavesCostNil(t *testing.T) {
+	msgs := []CodexMessage{turn(100, 0, 50)}
+	got := extractCodexUsage(msgs, "not-a-known-model")
+	if got == nil {
+		t.Fatal("expected non-nil usage for known token data")
+	}
+	if got.CostUSD != nil {
+		t.Fatalf("expected nil CostUSD for unknown model, got %v", *got.CostUSD)
+	}
+	// Tokens should still be populated.
+	if got.InputTokens == nil || *got.InputTokens != 100 {
+		t.Fatalf("InputTokens = %v, want 100", got.InputTokens)
+	}
+}
+
+func TestExtractCodexUsage_AllZeroTurnsIgnored(t *testing.T) {
+	// Turn events with all-zero usage are noise (e.g. turn.started without usage)
+	// and should not produce a usage record on their own.
+	msgs := []CodexMessage{turn(0, 0, 0), turn(0, 0, 0)}
+	if got := extractCodexUsage(msgs, "gpt-5"); got != nil {
+		t.Fatalf("expected nil usage when all turns are zero, got %+v", got)
+	}
+}

--- a/services/codex/cost_test.go
+++ b/services/codex/cost_test.go
@@ -42,8 +42,8 @@ func TestExtractCodexUsage_SumsAcrossTurns(t *testing.T) {
 	if *got.CacheReadTokens != 600 {
 		t.Fatalf("CacheReadTokens = %v, want 600", *got.CacheReadTokens)
 	}
-	if *got.CacheWriteTokens != 0 {
-		t.Fatalf("CacheWriteTokens should always be 0 for Codex, got %v", *got.CacheWriteTokens)
+	if got.CacheWriteTokens != nil {
+		t.Fatalf("CacheWriteTokens should be nil for Codex (not reported), got %v", *got.CacheWriteTokens)
 	}
 	if got.Model != "gpt-5-codex" {
 		t.Fatalf("Model = %q, want gpt-5-codex", got.Model)

--- a/services/codex/cost_test.go
+++ b/services/codex/cost_test.go
@@ -45,8 +45,8 @@ func TestExtractCodexUsage_SumsAcrossTurns(t *testing.T) {
 	if got.CacheWriteTokens != nil {
 		t.Fatalf("CacheWriteTokens should be nil for Codex (not reported), got %v", *got.CacheWriteTokens)
 	}
-	if got.Model != "gpt-5-codex" {
-		t.Fatalf("Model = %q, want gpt-5-codex", got.Model)
+	if got.Model == nil || *got.Model != "gpt-5-codex" {
+		t.Fatalf("Model = %v, want gpt-5-codex", got.Model)
 	}
 	// Cost should be computable from gpt-5-codex pricing.
 	// fresh = 1300 - 600 = 700 → 700/1M * 1.25 = 0.000875

--- a/services/opencode/cost.go
+++ b/services/opencode/cost.go
@@ -1,0 +1,178 @@
+package opencode
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"nairid/services"
+)
+
+// dbQueryTimeout caps how long the post-turn `opencode db` lookup can take.
+// The query is a simple indexed SELECT on a local SQLite file so a few
+// seconds is generous.
+const dbQueryTimeout = 10 * time.Second
+
+// openCodeMessageRow mirrors the JSON shape returned by `opencode db --format json`
+// when selecting message-level cost/tokens columns. Each row corresponds to
+// one assistant message that OpenCode produced during the just-finished run.
+type openCodeMessageRow struct {
+	Cost   float64           `json:"cost"`
+	Tokens openCodeTokensRow `json:"tokens"`
+	Model  string            `json:"modelID"`
+}
+
+type openCodeTokensRow struct {
+	Total     int64                  `json:"total"`
+	Input     int64                  `json:"input"`
+	Output    int64                  `json:"output"`
+	Reasoning int64                  `json:"reasoning"`
+	Cache     openCodeCacheTokensRow `json:"cache"`
+}
+
+type openCodeCacheTokensRow struct {
+	Write int64 `json:"write"`
+	Read  int64 `json:"read"`
+}
+
+// dbQueryFunc is the signature used to run `opencode db` queries.
+// Production code uses runOpenCodeDB; tests can inject a stub.
+type dbQueryFunc func(ctx context.Context, query string) ([]byte, error)
+
+// runOpenCodeDB shells out to `opencode db --format json "<query>"` and
+// returns raw stdout bytes. Stderr is folded into the error on failure.
+func runOpenCodeDB(ctx context.Context, query string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "opencode", "db", "--format", "json", query)
+	out, err := cmd.Output()
+	if err != nil {
+		stderr := ""
+		if ee, ok := err.(*exec.ExitError); ok {
+			stderr = strings.TrimSpace(string(ee.Stderr))
+		}
+		return nil, fmt.Errorf("opencode db query failed: %w (stderr: %s)", err, stderr)
+	}
+	return out, nil
+}
+
+// fetchOpenCodeUsage queries the local OpenCode SQLite database for every
+// assistant message in the given session that was created at or after
+// runStart (i.e. the just-completed `opencode run` invocation), and folds
+// them into a single CLIAgentUsage rollup.
+//
+// runStart is matched against OpenCode's millisecond epoch `time_created`
+// column. Pass a slightly-pre-launch wall clock so the query is robust to
+// minor clock skew between Go's time.Now() and OpenCode's internal stamps.
+//
+// Returns nil when no rows are found or any error occurs — the caller logs
+// and proceeds with cost-less messaging, since this is best-effort.
+func fetchOpenCodeUsage(
+	ctx context.Context,
+	sessionID string,
+	runStart time.Time,
+	query dbQueryFunc,
+) *services.CLIAgentUsage {
+	if sessionID == "" || sessionID == "unknown" {
+		return nil
+	}
+
+	// Embed sessionID and the unix-ms timestamp directly. Session IDs are
+	// short ASCII tokens like "ses_1ac4e246..." and the timestamp is a
+	// pure integer, so this is safe under any reasonable shell. We still
+	// do a paranoia check to reject any session ID containing a single
+	// quote, which would never appear in a real OpenCode id.
+	if strings.ContainsAny(sessionID, "'\\\";\n") {
+		return nil
+	}
+	runStartMs := runStart.UnixMilli()
+
+	q := fmt.Sprintf(
+		"SELECT "+
+			"json_extract(data, '$.cost') AS cost, "+
+			"json_extract(data, '$.tokens') AS tokens, "+
+			"json_extract(data, '$.modelID') AS modelID "+
+			"FROM message "+
+			"WHERE session_id = '%s' "+
+			"AND json_extract(data, '$.role') = 'assistant' "+
+			"AND time_created >= %d "+
+			"ORDER BY time_created ASC",
+		sessionID,
+		runStartMs,
+	)
+
+	cctx, cancel := context.WithTimeout(ctx, dbQueryTimeout)
+	defer cancel()
+
+	raw, err := query(cctx, q)
+	if err != nil {
+		return nil
+	}
+
+	// `opencode db` returns each row as a flat object with the SELECTed
+	// columns as keys. json_extract on the `tokens` object returns the
+	// nested JSON as a string, so we deserialise twice.
+	var rawRows []struct {
+		Cost   *float64 `json:"cost"`
+		Tokens *string  `json:"tokens"`
+		Model  *string  `json:"modelID"`
+	}
+	if err := json.Unmarshal(raw, &rawRows); err != nil {
+		return nil
+	}
+	if len(rawRows) == 0 {
+		return nil
+	}
+
+	var (
+		totalCost   float64
+		hasCost     bool
+		inputSum    int64
+		outputSum   int64
+		cacheRead   int64
+		cacheWrite  int64
+		hasTokens   bool
+		latestModel string
+	)
+	for _, r := range rawRows {
+		if r.Cost != nil {
+			totalCost += *r.Cost
+			hasCost = true
+		}
+		if r.Tokens != nil && *r.Tokens != "" {
+			var tk openCodeTokensRow
+			if err := json.Unmarshal([]byte(*r.Tokens), &tk); err == nil {
+				inputSum += tk.Input
+				outputSum += tk.Output
+				cacheRead += tk.Cache.Read
+				cacheWrite += tk.Cache.Write
+				hasTokens = true
+			}
+		}
+		if r.Model != nil && *r.Model != "" {
+			latestModel = *r.Model
+		}
+	}
+
+	if !hasCost && !hasTokens {
+		return nil
+	}
+
+	usage := &services.CLIAgentUsage{Model: latestModel}
+	if hasCost {
+		c := totalCost
+		usage.CostUSD = &c
+	}
+	if hasTokens {
+		in := inputSum
+		out := outputSum
+		cr := cacheRead
+		cw := cacheWrite
+		usage.InputTokens = &in
+		usage.OutputTokens = &out
+		usage.CacheReadTokens = &cr
+		usage.CacheWriteTokens = &cw
+	}
+	return usage
+}

--- a/services/opencode/cost.go
+++ b/services/opencode/cost.go
@@ -159,7 +159,11 @@ func fetchOpenCodeUsage(
 		return nil
 	}
 
-	usage := &services.CLIAgentUsage{Model: latestModel}
+	usage := &services.CLIAgentUsage{}
+	if latestModel != "" {
+		m := latestModel
+		usage.Model = &m
+	}
 	if hasCost {
 		c := totalCost
 		usage.CostUSD = &c

--- a/services/opencode/cost.go
+++ b/services/opencode/cost.go
@@ -16,15 +16,8 @@ import (
 // seconds is generous.
 const dbQueryTimeout = 10 * time.Second
 
-// openCodeMessageRow mirrors the JSON shape returned by `opencode db --format json`
-// when selecting message-level cost/tokens columns. Each row corresponds to
-// one assistant message that OpenCode produced during the just-finished run.
-type openCodeMessageRow struct {
-	Cost   float64           `json:"cost"`
-	Tokens openCodeTokensRow `json:"tokens"`
-	Model  string            `json:"modelID"`
-}
-
+// openCodeTokensRow mirrors the nested `tokens` JSON object returned by
+// `opencode db --format json` when selecting message-level cost columns.
 type openCodeTokensRow struct {
 	Total     int64                  `json:"total"`
 	Input     int64                  `json:"input"`

--- a/services/opencode/cost_test.go
+++ b/services/opencode/cost_test.go
@@ -1,0 +1,153 @@
+package opencode
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func stubQuery(rows []byte, err error) dbQueryFunc {
+	return func(_ context.Context, _ string) ([]byte, error) {
+		if err != nil {
+			return nil, err
+		}
+		return rows, nil
+	}
+}
+
+func TestFetchOpenCodeUsage_NilForEmptySession(t *testing.T) {
+	got := fetchOpenCodeUsage(context.Background(), "", time.Now(), stubQuery([]byte("[]"), nil))
+	if got != nil {
+		t.Fatalf("expected nil usage for empty session id, got %+v", got)
+	}
+
+	got = fetchOpenCodeUsage(context.Background(), "unknown", time.Now(), stubQuery([]byte("[]"), nil))
+	if got != nil {
+		t.Fatalf("expected nil usage for placeholder 'unknown' session id, got %+v", got)
+	}
+}
+
+func TestFetchOpenCodeUsage_SuspiciousSessionIDRejected(t *testing.T) {
+	got := fetchOpenCodeUsage(
+		context.Background(),
+		"ses_bad'; DROP TABLE message; --",
+		time.Now(),
+		stubQuery([]byte("[]"), nil),
+	)
+	if got != nil {
+		t.Fatalf("expected nil usage for suspicious session id, got %+v", got)
+	}
+}
+
+func TestFetchOpenCodeUsage_QueryErrorReturnsNil(t *testing.T) {
+	got := fetchOpenCodeUsage(
+		context.Background(),
+		"ses_1",
+		time.Now(),
+		stubQuery(nil, errors.New("db locked")),
+	)
+	if got != nil {
+		t.Fatalf("expected nil usage when DB query fails, got %+v", got)
+	}
+}
+
+func TestFetchOpenCodeUsage_EmptyRowsReturnsNil(t *testing.T) {
+	got := fetchOpenCodeUsage(context.Background(), "ses_1", time.Now(), stubQuery([]byte("[]"), nil))
+	if got != nil {
+		t.Fatalf("expected nil usage for zero matching rows, got %+v", got)
+	}
+}
+
+func TestFetchOpenCodeUsage_SingleRow(t *testing.T) {
+	row := []byte(`[
+		{
+			"cost": 0.0283605,
+			"tokens": "{\"total\":15902,\"input\":15800,\"output\":102,\"reasoning\":0,\"cache\":{\"write\":12,\"read\":3000}}",
+			"modelID": "gpt-5.3-codex"
+		}
+	]`)
+	got := fetchOpenCodeUsage(context.Background(), "ses_1", time.Now(), stubQuery(row, nil))
+	if got == nil {
+		t.Fatal("expected non-nil usage")
+	}
+	if got.CostUSD == nil || *got.CostUSD != 0.0283605 {
+		t.Fatalf("CostUSD = %v, want 0.0283605", got.CostUSD)
+	}
+	if got.InputTokens == nil || *got.InputTokens != 15800 {
+		t.Fatalf("InputTokens = %v, want 15800", got.InputTokens)
+	}
+	if got.OutputTokens == nil || *got.OutputTokens != 102 {
+		t.Fatalf("OutputTokens = %v, want 102", got.OutputTokens)
+	}
+	if got.CacheReadTokens == nil || *got.CacheReadTokens != 3000 {
+		t.Fatalf("CacheReadTokens = %v, want 3000", got.CacheReadTokens)
+	}
+	if got.CacheWriteTokens == nil || *got.CacheWriteTokens != 12 {
+		t.Fatalf("CacheWriteTokens = %v, want 12", got.CacheWriteTokens)
+	}
+	if got.Model != "gpt-5.3-codex" {
+		t.Fatalf("Model = %q, want gpt-5.3-codex", got.Model)
+	}
+}
+
+func TestFetchOpenCodeUsage_MultiRowSumsCorrectly(t *testing.T) {
+	// Two assistant messages within the same `opencode run` (model thinks → tool → finalizes).
+	// Cost and tokens should sum; model is taken from the latest row.
+	row := []byte(`[
+		{
+			"cost": 0.01,
+			"tokens": "{\"total\":1000,\"input\":900,\"output\":100,\"cache\":{\"write\":0,\"read\":50}}",
+			"modelID": "kimi-k2.5"
+		},
+		{
+			"cost": 0.02,
+			"tokens": "{\"total\":2000,\"input\":1800,\"output\":200,\"cache\":{\"write\":10,\"read\":150}}",
+			"modelID": "kimi-k2.6"
+		}
+	]`)
+	got := fetchOpenCodeUsage(context.Background(), "ses_2", time.Now(), stubQuery(row, nil))
+	if got == nil {
+		t.Fatal("expected non-nil usage for multi-row session")
+	}
+	if *got.CostUSD != 0.03 {
+		t.Fatalf("CostUSD sum = %v, want 0.03", *got.CostUSD)
+	}
+	if *got.InputTokens != 2700 {
+		t.Fatalf("InputTokens sum = %v, want 2700", *got.InputTokens)
+	}
+	if *got.OutputTokens != 300 {
+		t.Fatalf("OutputTokens sum = %v, want 300", *got.OutputTokens)
+	}
+	if *got.CacheReadTokens != 200 {
+		t.Fatalf("CacheReadTokens sum = %v, want 200", *got.CacheReadTokens)
+	}
+	if *got.CacheWriteTokens != 10 {
+		t.Fatalf("CacheWriteTokens sum = %v, want 10", *got.CacheWriteTokens)
+	}
+	if got.Model != "kimi-k2.6" {
+		t.Fatalf("Model = %q, want kimi-k2.6 (latest row)", got.Model)
+	}
+}
+
+func TestFetchOpenCodeUsage_FreeModelZeroCost(t *testing.T) {
+	// Free OpenCode models report cost=0 but still report tokens; we should
+	// propagate both rather than dropping the row.
+	row := []byte(`[
+		{
+			"cost": 0,
+			"tokens": "{\"total\":24274,\"input\":24258,\"output\":3,\"cache\":{\"write\":0,\"read\":0}}",
+			"modelID": "deepseek-v4-flash-free"
+		}
+	]`)
+	got := fetchOpenCodeUsage(context.Background(), "ses_3", time.Now(), stubQuery(row, nil))
+	if got == nil {
+		t.Fatal("expected non-nil usage for free model run")
+	}
+	if got.CostUSD == nil || *got.CostUSD != 0 {
+		t.Fatalf("CostUSD = %v, want 0", got.CostUSD)
+	}
+	if *got.InputTokens != 24258 {
+		t.Fatalf("InputTokens = %v, want 24258", *got.InputTokens)
+	}
+}

--- a/services/opencode/cost_test.go
+++ b/services/opencode/cost_test.go
@@ -86,8 +86,8 @@ func TestFetchOpenCodeUsage_SingleRow(t *testing.T) {
 	if got.CacheWriteTokens == nil || *got.CacheWriteTokens != 12 {
 		t.Fatalf("CacheWriteTokens = %v, want 12", got.CacheWriteTokens)
 	}
-	if got.Model != "gpt-5.3-codex" {
-		t.Fatalf("Model = %q, want gpt-5.3-codex", got.Model)
+	if got.Model == nil || *got.Model != "gpt-5.3-codex" {
+		t.Fatalf("Model = %v, want gpt-5.3-codex", got.Model)
 	}
 }
 
@@ -125,8 +125,8 @@ func TestFetchOpenCodeUsage_MultiRowSumsCorrectly(t *testing.T) {
 	if *got.CacheWriteTokens != 10 {
 		t.Fatalf("CacheWriteTokens sum = %v, want 10", *got.CacheWriteTokens)
 	}
-	if got.Model != "kimi-k2.6" {
-		t.Fatalf("Model = %q, want kimi-k2.6 (latest row)", got.Model)
+	if got.Model == nil || *got.Model != "kimi-k2.6" {
+		t.Fatalf("Model = %v, want kimi-k2.6 (latest row)", got.Model)
 	}
 }
 

--- a/services/opencode/opencode.go
+++ b/services/opencode/opencode.go
@@ -1,6 +1,7 @@
 package opencode
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -17,6 +18,11 @@ type OpenCodeService struct {
 	openCodeClient clients.OpenCodeClient
 	logDir         string
 	model          string
+
+	// dbQuery is the function used to read post-run cost rows from
+	// OpenCode's local SQLite. Defaulted to a shell-out to `opencode db`;
+	// tests inject a stub.
+	dbQuery dbQueryFunc
 }
 
 func NewOpenCodeService(openCodeClient clients.OpenCodeClient, logDir, model string) *OpenCodeService {
@@ -24,6 +30,7 @@ func NewOpenCodeService(openCodeClient clients.OpenCodeClient, logDir, model str
 		openCodeClient: openCodeClient,
 		logDir:         logDir,
 		model:          model,
+		dbQuery:        runOpenCodeDB,
 	}
 }
 
@@ -141,6 +148,7 @@ func (o *OpenCodeService) StartNewConversationWithOptions(
 		}
 	}
 
+	runStart := time.Now().Add(-1 * time.Second) // small skew tolerance
 	rawOutput, err := o.openCodeClient.StartNewSession(prompt, finalOptions, onLine)
 	if err != nil {
 		log.Error("Failed to start new OpenCode session: %v", err)
@@ -175,6 +183,7 @@ func (o *OpenCodeService) StartNewConversationWithOptions(
 	result := &services.CLIAgentResult{
 		Output:    output,
 		SessionID: sessionID,
+		Usage:     fetchOpenCodeUsage(context.Background(), sessionID, runStart, o.dbQuery),
 	}
 
 	log.Info("📋 Completed successfully - started new OpenCode conversation with session: %s", sessionID)
@@ -266,6 +275,7 @@ func (o *OpenCodeService) ContinueConversationWithOptions(
 		}
 	}
 
+	runStart := time.Now().Add(-1 * time.Second) // small skew tolerance
 	rawOutput, err := o.openCodeClient.ContinueSession(sessionID, prompt, finalOptions, onLine)
 	if err != nil {
 		log.Error("Failed to continue OpenCode session: %v", err)
@@ -300,6 +310,7 @@ func (o *OpenCodeService) ContinueConversationWithOptions(
 	result := &services.CLIAgentResult{
 		Output:    output,
 		SessionID: actualSessionID,
+		Usage:     fetchOpenCodeUsage(context.Background(), actualSessionID, runStart, o.dbQuery),
 	}
 
 	log.Info("📋 Completed successfully - continued OpenCode conversation with session: %s", actualSessionID)

--- a/services/pricing/codex.go
+++ b/services/pricing/codex.go
@@ -1,0 +1,88 @@
+package pricing
+
+import "strings"
+
+// codexModelPricing holds per-million-token rates in USD for an OpenAI/Codex model.
+// Cached input tokens are billed at a discount versus fresh input tokens.
+type codexModelPricing struct {
+	InputUSDPerMillion       float64
+	CachedInputUSDPerMillion float64
+	OutputUSDPerMillion      float64
+}
+
+// Public OpenAI pricing as of 2026-05. Values may drift; treat this as a
+// best-effort estimate. Pricing updates are a nairid release.
+//
+// Sources:
+//   - https://openai.com/api/pricing (gpt-5, gpt-5-codex families)
+//   - https://platform.openai.com/docs/models
+var codexPricingByModel = map[string]codexModelPricing{
+	// GPT-5 family
+	"gpt-5":      {InputUSDPerMillion: 1.25, CachedInputUSDPerMillion: 0.125, OutputUSDPerMillion: 10.00},
+	"gpt-5-mini": {InputUSDPerMillion: 0.25, CachedInputUSDPerMillion: 0.025, OutputUSDPerMillion: 2.00},
+	"gpt-5-nano": {InputUSDPerMillion: 0.05, CachedInputUSDPerMillion: 0.005, OutputUSDPerMillion: 0.40},
+
+	// Codex variants of GPT-5 (priced like their base model)
+	"gpt-5-codex":      {InputUSDPerMillion: 1.25, CachedInputUSDPerMillion: 0.125, OutputUSDPerMillion: 10.00},
+	"gpt-5-mini-codex": {InputUSDPerMillion: 0.25, CachedInputUSDPerMillion: 0.025, OutputUSDPerMillion: 2.00},
+
+	// Legacy o-series fallbacks (in case older sessions still run)
+	"o3":      {InputUSDPerMillion: 2.00, CachedInputUSDPerMillion: 0.50, OutputUSDPerMillion: 8.00},
+	"o3-mini": {InputUSDPerMillion: 1.10, CachedInputUSDPerMillion: 0.55, OutputUSDPerMillion: 4.40},
+	"o4-mini": {InputUSDPerMillion: 1.10, CachedInputUSDPerMillion: 0.275, OutputUSDPerMillion: 4.40},
+}
+
+// CodexCostUSD computes the dollar cost of a single Codex turn from its
+// reported token usage. cachedInputTokens are subtracted from inputTokens
+// to avoid double-billing, then billed at the discounted cache rate.
+//
+// Returns (cost, true) when the model is recognised. Returns (0, false)
+// when the model is unknown so callers can leave cost NULL upstream.
+func CodexCostUSD(model string, inputTokens, cachedInputTokens, outputTokens int64) (float64, bool) {
+	p, ok := lookupCodexPricing(model)
+	if !ok {
+		return 0, false
+	}
+
+	// Defensive clamp: cached can never exceed reported input.
+	freshInput := inputTokens - cachedInputTokens
+	if freshInput < 0 {
+		freshInput = 0
+	}
+	if cachedInputTokens < 0 {
+		cachedInputTokens = 0
+	}
+	if outputTokens < 0 {
+		outputTokens = 0
+	}
+
+	const perMillion = 1_000_000.0
+	cost := (float64(freshInput)/perMillion)*p.InputUSDPerMillion +
+		(float64(cachedInputTokens)/perMillion)*p.CachedInputUSDPerMillion +
+		(float64(outputTokens)/perMillion)*p.OutputUSDPerMillion
+	return cost, true
+}
+
+// lookupCodexPricing returns the pricing entry for a model, accepting both
+// canonical model ids ("gpt-5-codex") and snapshot/date-stamped variants
+// ("gpt-5-codex-2026-04-01") by prefix matching.
+func lookupCodexPricing(model string) (codexModelPricing, bool) {
+	if p, ok := codexPricingByModel[model]; ok {
+		return p, true
+	}
+	// Prefix match for snapshot-suffixed model ids. Try longest first so
+	// "gpt-5-codex-2026-04-01" matches "gpt-5-codex" before "gpt-5".
+	var best string
+	for prefix := range codexPricingByModel {
+		if !strings.HasPrefix(model, prefix+"-") {
+			continue
+		}
+		if len(prefix) > len(best) {
+			best = prefix
+		}
+	}
+	if best == "" {
+		return codexModelPricing{}, false
+	}
+	return codexPricingByModel[best], true
+}

--- a/services/pricing/codex_test.go
+++ b/services/pricing/codex_test.go
@@ -1,0 +1,114 @@
+package pricing
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCodexCostUSD_KnownModels(t *testing.T) {
+	tests := []struct {
+		name              string
+		model             string
+		inputTokens       int64
+		cachedInputTokens int64
+		outputTokens      int64
+		want              float64
+	}{
+		{
+			name:              "gpt-5 single turn no cache",
+			model:             "gpt-5",
+			inputTokens:       1_000_000,
+			cachedInputTokens: 0,
+			outputTokens:      100_000,
+			// 1M input * $1.25 + 0.1M output * $10.00 = 1.25 + 1.00 = 2.25
+			want: 2.25,
+		},
+		{
+			name:              "gpt-5-codex with cached inputs",
+			model:             "gpt-5-codex",
+			inputTokens:       1_000_000,
+			cachedInputTokens: 800_000, // fresh = 200_000
+			outputTokens:      50_000,
+			// fresh 0.2M * $1.25 + cached 0.8M * $0.125 + output 0.05M * $10.00
+			// = 0.25 + 0.10 + 0.50 = 0.85
+			want: 0.85,
+		},
+		{
+			name:              "gpt-5-mini small turn",
+			model:             "gpt-5-mini",
+			inputTokens:       10_000,
+			cachedInputTokens: 0,
+			outputTokens:      1_000,
+			// 10k * 0.25/1M + 1k * 2.00/1M = 0.0025 + 0.002 = 0.0045
+			want: 0.0045,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := CodexCostUSD(tt.model, tt.inputTokens, tt.cachedInputTokens, tt.outputTokens)
+			if !ok {
+				t.Fatalf("expected ok=true for known model %q", tt.model)
+			}
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Fatalf("CodexCostUSD(%q) = %v, want %v", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCodexCostUSD_SnapshotModelMatches(t *testing.T) {
+	// Snapshot-suffixed id should fall back to its base model pricing.
+	got, ok := CodexCostUSD("gpt-5-codex-2026-04-01", 1_000_000, 0, 0)
+	if !ok {
+		t.Fatalf("expected snapshot model to match gpt-5-codex base pricing")
+	}
+	const want = 1.25 // 1M input tokens * $1.25/M
+	if math.Abs(got-want) > 1e-9 {
+		t.Fatalf("snapshot match cost = %v, want %v", got, want)
+	}
+}
+
+func TestCodexCostUSD_PrefersLongerPrefix(t *testing.T) {
+	// "gpt-5-mini-codex" should match its own entry, not the shorter "gpt-5" prefix.
+	got, ok := CodexCostUSD("gpt-5-mini-codex-2026-05-01", 1_000_000, 0, 0)
+	if !ok {
+		t.Fatalf("expected match for snapshot of gpt-5-mini-codex")
+	}
+	const want = 0.25 // gpt-5-mini-codex input price per 1M
+	if math.Abs(got-want) > 1e-9 {
+		t.Fatalf("longer-prefix match cost = %v, want %v", got, want)
+	}
+}
+
+func TestCodexCostUSD_UnknownModel(t *testing.T) {
+	_, ok := CodexCostUSD("some-unknown-model", 100, 0, 100)
+	if ok {
+		t.Fatalf("expected ok=false for unknown model")
+	}
+}
+
+func TestCodexCostUSD_DefensiveNegatives(t *testing.T) {
+	// Negative inputs are clamped to zero, not propagated.
+	got, ok := CodexCostUSD("gpt-5", -5, -5, -5)
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if got != 0 {
+		t.Fatalf("expected zero cost for all-negative inputs, got %v", got)
+	}
+}
+
+func TestCodexCostUSD_CachedExceedsInputClamps(t *testing.T) {
+	// If cached > input the fresh count is clamped to zero so we never bill negative
+	// fresh tokens. cached itself is still billed (the reported value is the source of truth).
+	got, ok := CodexCostUSD("gpt-5", 100, 1_000, 0)
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	// fresh = 0 (clamped), cached = 1000 * 0.125/1M = 0.000125
+	const want = 0.000125
+	if math.Abs(got-want) > 1e-9 {
+		t.Fatalf("cached-clamp cost = %v, want %v", got, want)
+	}
+}

--- a/services/services.go
+++ b/services/services.go
@@ -2,10 +2,24 @@ package services
 
 import "nairid/models"
 
-// CLIAgentResult represents the result of a CLI agent conversation
+// CLIAgentResult represents the result of a CLI agent conversation.
+// Cost and Usage fields are optional; harnesses that do not report them
+// (e.g. Cursor) leave them nil and the backend persists NULL columns.
 type CLIAgentResult struct {
 	Output    string
 	SessionID string
+	Usage     *CLIAgentUsage
+}
+
+// CLIAgentUsage holds optional per-message cost and token usage data
+// extracted from a CLI harness after a conversation turn completes.
+type CLIAgentUsage struct {
+	CostUSD          *float64
+	InputTokens      *int64
+	OutputTokens     *int64
+	CacheReadTokens  *int64
+	CacheWriteTokens *int64
+	Model            string
 }
 
 // ProgressEmitter is a callback for emitting progress messages during agent execution

--- a/services/services.go
+++ b/services/services.go
@@ -13,13 +13,18 @@ type CLIAgentResult struct {
 
 // CLIAgentUsage holds optional per-message cost and token usage data
 // extracted from a CLI harness after a conversation turn completes.
+// Every field is a pointer because no single harness populates all of
+// them: Cursor reports nothing, Codex cannot report cache writes,
+// OpenCode is best-effort, and Claude may omit cost on cache-only
+// turns. Use nil to mean "the harness did not report this value" so
+// callers can persist NULL rather than a misleading zero/empty value.
 type CLIAgentUsage struct {
 	CostUSD          *float64
 	InputTokens      *int64
 	OutputTokens     *int64
 	CacheReadTokens  *int64
 	CacheWriteTokens *int64
-	Model            string
+	Model            *string
 }
 
 // ProgressEmitter is a callback for emitting progress messages during agent execution


### PR DESCRIPTION
## Summary

Extracts cost and token usage from each CLI harness after a conversation turn finishes and attaches it to the outgoing `assistant_message_v1` payload so the backend can persist it on `conversation_messages`.

This is half 2 of 2 — it depends on the matching ccbackend PR (presmihaylov/claudecontrol#938) landing first, which adds the schema columns and API surface. The wire change here is backward compatible since all cost fields are `omitempty`, so a backend without the matching change will just ignore them.

## Deploy order

Merge + deploy presmihaylov/claudecontrol#938 **first**, then merge this PR, release nairid, bump the Docker image, and roll the v2 fleet.

## Per-harness behaviour

- **Claude**: `total_cost_usd` comes from the final `result` event; tokens are taken from the result's `usage` rollup when present, else summed across per-`assistant`-event usage blocks.
- **Codex**: input / cached / output tokens summed across `turn.completed` events; cost is computed via a small local pricing table in `nairid/services/pricing` keyed by model id. (Kept in nairid to keep the backend a dumb persistence layer; pricing updates ship with nairid.)
- **OpenCode**: shells out to `opencode db --format json` after the subprocess exits to query the local SQLite database for assistant messages created during this run, then sums cost and tokens. The DB read is best-effort: on any failure the message is sent with NULL cost columns and the turn does not fail.
- **Cursor**: emits nothing; leaves all cost fields nil.

## What changed

- `services.CLIAgentResult` grows an optional `Usage *CLIAgentUsage` field. New `CLIAgentUsage` struct holds `CostUSD`, `InputTokens`, `OutputTokens`, `CacheReadTokens`, `CacheWriteTokens`, `Model`.
- `models.AssistantMessagePayload` mirrors those fields on the wire (all `omitempty`).
- Each harness service populates `Usage` after the subprocess exits:
  - `services/claude/cost.go` — `extractClaudeUsage`
  - `services/codex/cost.go` — `extractCodexUsage`, with cost via `services/pricing/codex.go`
  - `services/opencode/cost.go` — `fetchOpenCodeUsage` (post-turn `opencode db` query)
- `handlers/messages.go` wires `claudeResult.Usage` onto the outgoing payload via a new `applyUsageToAssistantPayload` helper.
- Unit tests for every new code path.

## Test plan

- [ ] Tests pass (`make test`)
- [ ] Lint clean (`make lint`) — note: 1 pre-existing staticcheck issue in `handlers/message_sender_test.go:193` is NOT touched
- [ ] After merge + nairid release + Docker image bump + v2 fleet rollout, hit the public API for a message produced by a Claude/OpenCode agent and confirm `cost_usd` is populated
- [ ] For Cursor jobs, confirm `cost_usd` stays null in the API response

## Gotchas

- OpenCode DB read uses the `opencode` binary in PATH. Inside the eksecd container that's the Bun-bundled binary. If the binary moves, cost lookups silently no-op (the turn succeeds without cost data).
- Codex pricing table in `services/pricing/codex.go` reflects public OpenAI pricing as of 2026-05. Updates require a nairid release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)