### PR TITLE
fix: populate cost_usd for Codex platform ids + cross-user OpenCode db lookup

### DIFF
--- a/services/opencode/cost.go
+++ b/services/opencode/cost.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"nairid/clients"
+	"nairid/core/log"
 	"nairid/services"
 )
 
@@ -35,10 +37,26 @@ type openCodeCacheTokensRow struct {
 // Production code uses runOpenCodeDB; tests can inject a stub.
 type dbQueryFunc func(ctx context.Context, query string) ([]byte, error)
 
+// buildOpenCodeDBCmd constructs the exec.Cmd that runOpenCodeDB will execute.
+// Extracted so the cross-user routing can be asserted in a regression test
+// (see cost_test.go) without actually shelling out.
+//
+// The lookup MUST run as the same user (and with the same HOME) as the
+// `opencode run` subprocess that just finished, otherwise OpenCode resolves
+// its SQLite path from the calling user's $HOME and reads an empty database.
+// In managed-mode containers nairid runs as ccagent but the agent subprocess
+// runs as agentrunner, so we go through clients.BuildAgentCommandWithContext
+// which routes via `sudo -u agentrunner` with HOME=/home/agentrunner injected.
+// In self-hosted mode this falls through to the current user, which is also
+// the user that ran the OpenCode subprocess.
+func buildOpenCodeDBCmd(ctx context.Context, query string) *exec.Cmd {
+	return clients.BuildAgentCommandWithContext(ctx, "opencode", "db", "--format", "json", query)
+}
+
 // runOpenCodeDB shells out to `opencode db --format json "<query>"` and
 // returns raw stdout bytes. Stderr is folded into the error on failure.
 func runOpenCodeDB(ctx context.Context, query string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, "opencode", "db", "--format", "json", query)
+	cmd := buildOpenCodeDBCmd(ctx, query)
 	out, err := cmd.Output()
 	if err != nil {
 		stderr := ""
@@ -68,6 +86,7 @@ func fetchOpenCodeUsage(
 	query dbQueryFunc,
 ) *services.CLIAgentUsage {
 	if sessionID == "" || sessionID == "unknown" {
+		log.Warn("OpenCode cost lookup skipped: missing session id (got %q)", sessionID)
 		return nil
 	}
 
@@ -77,6 +96,7 @@ func fetchOpenCodeUsage(
 	// do a paranoia check to reject any session ID containing a single
 	// quote, which would never appear in a real OpenCode id.
 	if strings.ContainsAny(sessionID, "'\\\";\n") {
+		log.Warn("OpenCode cost lookup skipped: suspicious session id rejected: %q", sessionID)
 		return nil
 	}
 	runStartMs := runStart.UnixMilli()
@@ -100,6 +120,7 @@ func fetchOpenCodeUsage(
 
 	raw, err := query(cctx, q)
 	if err != nil {
+		log.Warn("OpenCode cost lookup: db query failed for session %s: %v", sessionID, err)
 		return nil
 	}
 
@@ -112,9 +133,11 @@ func fetchOpenCodeUsage(
 		Model  *string  `json:"modelID"`
 	}
 	if err := json.Unmarshal(raw, &rawRows); err != nil {
+		log.Warn("OpenCode cost lookup: failed to parse db output for session %s: %v", sessionID, err)
 		return nil
 	}
 	if len(rawRows) == 0 {
+		log.Warn("OpenCode cost lookup: no assistant rows found for session %s (cost will be NULL)", sessionID)
 		return nil
 	}
 
@@ -149,6 +172,7 @@ func fetchOpenCodeUsage(
 	}
 
 	if !hasCost && !hasTokens {
+		log.Warn("OpenCode cost lookup: rows returned but no cost or tokens parseable for session %s", sessionID)
 		return nil
 	}
 

--- a/services/opencode/cost_test.go
+++ b/services/opencode/cost_test.go
@@ -3,9 +3,45 @@ package opencode
 import (
 	"context"
 	"errors"
+	"os"
+	"strings"
 	"testing"
 	"time"
 )
+
+// In managed-mode containers the `opencode run` subprocess executes as
+// `agentrunner` (HOME=/home/agentrunner) while nairid runs as ccagent.
+// The post-turn cost lookup MUST cross that user boundary, otherwise it
+// reads /home/ccagent/.local/share/opencode/opencode.db which is empty.
+// This regression-tests that buildOpenCodeDBCmd routes through sudo with
+// HOME pointed at the agent-exec user when AGENT_EXEC_USER is set.
+func TestBuildOpenCodeDBCmd_RoutesThroughAgentExecUser(t *testing.T) {
+	t.Setenv("AGENT_EXEC_USER", "agentrunner")
+
+	cmd := buildOpenCodeDBCmd(context.Background(), "SELECT 1")
+	if cmd.Args[0] != "sudo" {
+		t.Fatalf("expected sudo wrapper in managed mode, got argv[0]=%q (full: %v)", cmd.Args[0], cmd.Args)
+	}
+	// sudo -u agentrunner bash -c <script>
+	if len(cmd.Args) != 6 {
+		t.Fatalf("expected 6 sudo args, got %d: %v", len(cmd.Args), cmd.Args)
+	}
+	bashScript := cmd.Args[5]
+	if !strings.Contains(bashScript, "HOME=/home/agentrunner") {
+		t.Errorf("bash script should set HOME=/home/agentrunner so opencode db reads the agent's SQLite, got: %s", bashScript)
+	}
+	if !strings.Contains(bashScript, "opencode 'db' '--format' 'json'") {
+		t.Errorf("bash script should invoke `opencode db --format json`, got: %s", bashScript)
+	}
+}
+
+func TestBuildOpenCodeDBCmd_SelfHostedRunsDirectly(t *testing.T) {
+	_ = os.Unsetenv("AGENT_EXEC_USER")
+	cmd := buildOpenCodeDBCmd(context.Background(), "SELECT 1")
+	if cmd.Args[0] != "opencode" {
+		t.Fatalf("expected direct invocation in self-hosted mode, got argv[0]=%q (full: %v)", cmd.Args[0], cmd.Args)
+	}
+}
 
 func stubQuery(rows []byte, err error) dbQueryFunc {
 	return func(_ context.Context, _ string) ([]byte, error) {

--- a/services/pricing/codex.go
+++ b/services/pricing/codex.go
@@ -1,6 +1,9 @@
 package pricing
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
 // codexModelPricing holds per-million-token rates in USD for an OpenAI/Codex model.
 // Cached input tokens are billed at a discount versus fresh input tokens.
@@ -63,15 +66,45 @@ func CodexCostUSD(model string, inputTokens, cachedInputTokens, outputTokens int
 	return cost, true
 }
 
-// lookupCodexPricing returns the pricing entry for a model, accepting both
-// canonical model ids ("gpt-5-codex") and snapshot/date-stamped variants
-// ("gpt-5-codex-2026-04-01") by prefix matching.
+// platformMinorVersionRe strips the dotted minor version from platform-flavoured
+// Codex model ids ("gpt-5.4-mini" → "gpt-5-mini"). The Nairi platform exposes
+// Codex models under names like gpt-5.4-mini / gpt-5.5-pro / gpt-5.3-codex,
+// which OpenAI's public pricing pages do not list verbatim. We collapse the
+// `.X` segment so the canonical OpenAI keys ("gpt-5-mini", "gpt-5-codex", …)
+// keep matching. The capture group preserves the major version and any suffix.
+var platformMinorVersionRe = regexp.MustCompile(`^(gpt-\d+)\.\d+(-.+)?$`)
+
+// lookupCodexPricing returns the pricing entry for a model, accepting:
+//   - canonical OpenAI model ids ("gpt-5-codex")
+//   - snapshot / date-stamped variants ("gpt-5-codex-2026-04-01") via prefix match
+//   - platform-flavoured ids with a dotted minor version ("gpt-5.4-mini",
+//     "gpt-5.3-codex") by normalising "gpt-N.X[-suffix]" → "gpt-N[-suffix]"
+//     before lookup, then falling back to the prefix matcher.
 func lookupCodexPricing(model string) (codexModelPricing, bool) {
 	if p, ok := codexPricingByModel[model]; ok {
 		return p, true
 	}
-	// Prefix match for snapshot-suffixed model ids. Try longest first so
-	// "gpt-5-codex-2026-04-01" matches "gpt-5-codex" before "gpt-5".
+	if p, ok := matchPrefix(model); ok {
+		return p, true
+	}
+	// Platform-flavoured ids: collapse the .X minor segment and retry.
+	if m := platformMinorVersionRe.FindStringSubmatch(model); m != nil {
+		normalized := m[1] + m[2] // e.g. "gpt-5" + "-mini" = "gpt-5-mini"
+		if p, ok := codexPricingByModel[normalized]; ok {
+			return p, true
+		}
+		if p, ok := matchPrefix(normalized); ok {
+			return p, true
+		}
+	}
+	return codexModelPricing{}, false
+}
+
+// matchPrefix returns the longest pricing entry whose key is a prefix of
+// model (matched on full hyphen segments). Used for snapshot-suffixed ids
+// and for normalised platform ids that include a suffix we do not list
+// verbatim (e.g. "gpt-5-pro" → fall back to "gpt-5").
+func matchPrefix(model string) (codexModelPricing, bool) {
 	var best string
 	for prefix := range codexPricingByModel {
 		if !strings.HasPrefix(model, prefix+"-") {

--- a/services/pricing/codex_test.go
+++ b/services/pricing/codex_test.go
@@ -99,6 +99,74 @@ func TestCodexCostUSD_DefensiveNegatives(t *testing.T) {
 	}
 }
 
+// Platform-flavoured model ids ("gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.5", "gpt-5.5-pro")
+// are what the Nairi platform actually exposes and what the Codex CLI reports back at
+// the end of a turn. The pricing table is keyed on OpenAI's canonical ids, so the
+// lookup must normalise the dotted-minor segment ("gpt-N.X" → "gpt-N") before falling
+// through to the prefix matcher for unknown suffixes like "-pro" / "-base".
+func TestCodexCostUSD_PlatformDottedMinorVersionIds(t *testing.T) {
+	tests := []struct {
+		name        string
+		model       string
+		inputTokens int64
+		want        float64
+	}{
+		{
+			name:        "gpt-5.4-mini normalises to gpt-5-mini",
+			model:       "gpt-5.4-mini",
+			inputTokens: 1_000_000,
+			want:        0.25, // gpt-5-mini input rate
+		},
+		{
+			name:        "gpt-5.3-codex normalises to gpt-5-codex",
+			model:       "gpt-5.3-codex",
+			inputTokens: 1_000_000,
+			want:        1.25, // gpt-5-codex input rate
+		},
+		{
+			name:        "gpt-5.5 normalises to gpt-5",
+			model:       "gpt-5.5",
+			inputTokens: 1_000_000,
+			want:        1.25, // gpt-5 input rate
+		},
+		{
+			name:        "gpt-5.5-pro: -pro suffix unknown → prefix-matches gpt-5",
+			model:       "gpt-5.5-pro",
+			inputTokens: 1_000_000,
+			want:        1.25,
+		},
+		{
+			name:        "gpt-5.2-base: -base suffix unknown → prefix-matches gpt-5",
+			model:       "gpt-5.2-base",
+			inputTokens: 1_000_000,
+			want:        1.25,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := CodexCostUSD(tt.model, tt.inputTokens, 0, 0)
+			if !ok {
+				t.Fatalf("expected ok=true for platform model %q", tt.model)
+			}
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Fatalf("CodexCostUSD(%q) = %v, want %v", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+// Negative case: a model that does not match either canonical, snapshot, or
+// platform-dotted naming is still rejected so callers leave cost NULL.
+func TestCodexCostUSD_PlatformDottedMinorVersionStillRejectsGarbage(t *testing.T) {
+	if _, ok := CodexCostUSD("gpt-5.4.1-mini", 1_000_000, 0, 0); ok {
+		t.Fatalf("expected ok=false: 'gpt-5.4.1-mini' does not match the gpt-N.X[-suffix] pattern")
+	}
+	if _, ok := CodexCostUSD("gpt-99.0-mini", 1_000_000, 0, 0); ok {
+		t.Fatalf("expected ok=false: 'gpt-99.0-mini' normalises to 'gpt-99-mini' which is not in the pricing table")
+	}
+}
+
 func TestCodexCostUSD_CachedExceedsInputClamps(t *testing.T) {
 	// If cached > input the fresh count is clamped to zero so we never bill negative
 	// fresh tokens. cached itself is still billed (the reported value is the source of truth).


### PR DESCRIPTION
## Summary

Two follow-ups to #210 surfaced by an end-to-end test of the per-message cost emission on `agents-org-eksec-v2` (running nairid `0.0.111`). Claude works perfectly; Codex and OpenCode each have one distinct gap. This PR fixes both.

## What's broken in 0.0.111

| Harness | Symptom | Root cause |
|---|---|---|
| Codex | tokens + model populated, `cost_usd` NULL | `services/pricing/codex.go` keys on OpenAI's public model names (`gpt-5`, `gpt-5-mini`, `gpt-5-codex`); the Nairi platform actually exposes `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.5`, etc. → `lookupCodexPricing` returns `(0, false)`, `omitempty` drops the field. |
| OpenCode | nothing populated (cost, tokens, model all NULL) | `runOpenCodeDB` used plain `exec.CommandContext`, so `opencode db` resolved its SQLite path from `ccagent`'s `$HOME`. The actual `opencode run` subprocess runs as `agentrunner` and writes to `/home/agentrunner/.local/share/opencode/opencode.db`. Verified empirically inside a v0.0.111 container. |

Both branches in `fetchOpenCodeUsage` also silently returned `nil` on every error path — even when present, this kind of bug was effectively invisible in container logs.

## What changed

**`services/pricing/codex.go`**
- Added `platformMinorVersionRe = ^(gpt-\d+)\.\d+(-.+)?$` and a normalisation step in `lookupCodexPricing`: `gpt-5.4-mini` → `gpt-5-mini`, `gpt-5.3-codex` → `gpt-5-codex`, `gpt-5.5` → `gpt-5`. Unknown suffixes (`-pro`, `-base`) fall through to the existing prefix matcher → base model pricing.
- Extracted the prefix-match into a `matchPrefix` helper so the two-stage lookup (exact → prefix → normalised+exact → normalised+prefix) reads cleanly.
- Pricing values are unchanged; this is a key-matching fix only.

**`services/opencode/cost.go`**
- Extracted `buildOpenCodeDBCmd` so the cross-user routing can be asserted in a regression test without shelling out.
- Swapped its body from `exec.CommandContext` to `clients.BuildAgentCommandWithContext` — routes through `sudo -u agentrunner bash -c '... HOME=/home/agentrunner ... opencode db ...'` in managed mode, stays direct in self-hosted mode. Reuses the same mechanism the actual `opencode run` already goes through, so the two paths always agree on where the SQLite lives.
- Added `log.Warn` on every silent-fail branch in `fetchOpenCodeUsage` (empty/`unknown` session id, suspicious id, db query error, JSON parse error, zero rows, no cost & no tokens). Behaviour is unchanged — these still return `nil` so the assistant message goes out without cost columns — but the next regression of this shape will be visible in container logs.

## Tests

New (all pass):
- `TestCodexCostUSD_PlatformDottedMinorVersionIds` — 5 sub-cases covering `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.5`, `gpt-5.5-pro`, `gpt-5.2-base`.
- `TestCodexCostUSD_PlatformDottedMinorVersionStillRejectsGarbage` — `gpt-5.4.1-mini` and `gpt-99.0-mini` correctly return `(0, false)`.
- `TestBuildOpenCodeDBCmd_RoutesThroughAgentExecUser` — asserts the sudo wrapper + `HOME=/home/agentrunner` in the bash script when `AGENT_EXEC_USER=agentrunner`.
- `TestBuildOpenCodeDBCmd_SelfHostedRunsDirectly` — direct `opencode` invocation when `AGENT_EXEC_USER` is unset.

Existing tests in both packages are untouched and still green.

## Test plan
- [x] `go test -count=1 ./...` — all packages green
- [x] `go vet ./services/pricing/... ./services/opencode/...` — clean
- [ ] After merge + nairid release + Docker image bump + v2 rollout, re-run the e2e test that surfaced these: send a one-shot prompt to a Codex agent (e.g. `gpt-5.4-mini`) and an OpenCode agent (e.g. `glm-5`) and confirm `cost_usd` is populated on both assistant messages.

## Deploy

Small bug-fix on top of 0.0.111 → patch bump to 0.0.112 is appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)