### PR TITLE
Make CLI session timeout configurable via NAIRI_MAX_SESSION_MS

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ export NAIRI_API_KEY=your_api_key_here
 
 You can generate an API key from the Nairi dashboard.
 
+#### Optional Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `NAIRI_MAX_SESSION_MS` | `3600000` (1 hour) | Maximum duration (in milliseconds) of a single agent CLI invocation before nairid kills the process. Bump this when running long single-turn tasks; the underlying CLI keeps streaming output across the whole window. `EKSEC_MAX_SESSION_MS` is accepted as a legacy fallback. Invalid or non-positive values are ignored and the default is used. |
+
 #### Running nairid
 
 Once setup is complete, run nairid in your repository directory.

--- a/clients/claude/claude.go
+++ b/clients/claude/claude.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 
 	"nairid/clients"
 	"nairid/core"
@@ -49,7 +50,8 @@ func (c *ClaudeClient) StartNewSession(prompt string, options *clients.ClaudeOpt
 	log.Info("Starting new Claude session with prompt: %s", prompt)
 	log.Info("Command arguments: %v", args)
 
-	ctx, cancel := context.WithTimeout(context.Background(), clients.DefaultSessionTimeout)
+	timeout := clients.SessionTimeout()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	cmd := c.buildCommand(ctx, options, args)
@@ -57,10 +59,10 @@ func (c *ClaudeClient) StartNewSession(prompt string, options *clients.ClaudeOpt
 		cmd.Stdin = promptStdin
 	}
 
-	log.Info("Running Claude command (timeout: %s)", clients.DefaultSessionTimeout)
+	log.Info("Running Claude command (timeout: %s)", timeout)
 	result, err := clients.RunCommandStreaming(ctx, cmd, onLine)
 	if err != nil {
-		return "", handleCommandError(ctx, err, "Claude")
+		return "", handleCommandError(ctx, err, "Claude", timeout)
 	}
 
 	log.Info("Claude command completed successfully, outputLength: %d", len(result))
@@ -96,7 +98,8 @@ func (c *ClaudeClient) ContinueSession(sessionID, prompt string, options *client
 	log.Info("Executing Claude command with sessionID: %s, prompt: %s", sessionID, prompt)
 	log.Info("Command arguments: %v", args)
 
-	ctx, cancel := context.WithTimeout(context.Background(), clients.DefaultSessionTimeout)
+	timeout := clients.SessionTimeout()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	cmd := c.buildCommand(ctx, options, args)
@@ -104,10 +107,10 @@ func (c *ClaudeClient) ContinueSession(sessionID, prompt string, options *client
 		cmd.Stdin = promptStdin
 	}
 
-	log.Info("Running Claude command (timeout: %s)", clients.DefaultSessionTimeout)
+	log.Info("Running Claude command (timeout: %s)", timeout)
 	result, err := clients.RunCommandStreaming(ctx, cmd, onLine)
 	if err != nil {
-		return "", handleCommandError(ctx, err, "Claude")
+		return "", handleCommandError(ctx, err, "Claude", timeout)
 	}
 
 	log.Info("Claude command completed successfully, outputLength: %d", len(result))
@@ -128,13 +131,13 @@ func (c *ClaudeClient) buildPermissionArgs() []string {
 
 // handleCommandError converts a clients.CommandError to a core.ErrClaudeCommandErr,
 // including timeout detection via context deadline.
-func handleCommandError(ctx context.Context, err error, agentName string) error {
+func handleCommandError(ctx context.Context, err error, agentName string, timeout time.Duration) error {
 	var cmdErr *clients.CommandError
 	if errors.As(err, &cmdErr) {
 		if ctx.Err() == context.DeadlineExceeded {
-			log.Error("⏰ %s session timed out after %s", agentName, clients.DefaultSessionTimeout)
+			log.Error("⏰ %s session timed out after %s", agentName, timeout)
 			return &core.ErrClaudeCommandErr{
-				Err:    fmt.Errorf("session timed out after %s: %w", clients.DefaultSessionTimeout, cmdErr.Err),
+				Err:    fmt.Errorf("session timed out after %s: %w", timeout, cmdErr.Err),
 				Output: cmdErr.Output,
 			}
 		}

--- a/clients/codex/codex.go
+++ b/clients/codex/codex.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"nairid/clients"
 	"nairid/core"
@@ -31,7 +32,8 @@ func (c *CodexClient) StartNewSession(prompt string, options *clients.CodexOptio
 	log.Info("Starting new Codex session with prompt: %s", prompt)
 	log.Info("Command arguments: %v", args)
 
-	ctx, cancel := context.WithTimeout(context.Background(), clients.DefaultSessionTimeout)
+	timeout := clients.SessionTimeout()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	cmd := clients.BuildAgentCommandWithContext(ctx, "codex", args...)
@@ -39,10 +41,10 @@ func (c *CodexClient) StartNewSession(prompt string, options *clients.CodexOptio
 		cmd.Dir = c.workDir
 	}
 
-	log.Info("Running Codex command (timeout: %s)", clients.DefaultSessionTimeout)
+	log.Info("Running Codex command (timeout: %s)", timeout)
 	result, err := clients.RunCommandStreaming(ctx, cmd, onLine)
 	if err != nil {
-		return "", handleCommandError(ctx, err, "Codex")
+		return "", handleCommandError(ctx, err, "Codex", timeout)
 	}
 
 	log.Info("Codex command completed successfully, outputLength: %d", len(result))
@@ -62,7 +64,8 @@ func (c *CodexClient) ContinueSession(threadID, prompt string, options *clients.
 	log.Info("Executing Codex command with threadID: %s, prompt: %s", threadID, prompt)
 	log.Info("Command arguments: %v", args)
 
-	ctx, cancel := context.WithTimeout(context.Background(), clients.DefaultSessionTimeout)
+	timeout := clients.SessionTimeout()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	cmd := clients.BuildAgentCommandWithContext(ctx, "codex", args...)
@@ -70,10 +73,10 @@ func (c *CodexClient) ContinueSession(threadID, prompt string, options *clients.
 		cmd.Dir = c.workDir
 	}
 
-	log.Info("Running Codex command (timeout: %s)", clients.DefaultSessionTimeout)
+	log.Info("Running Codex command (timeout: %s)", timeout)
 	result, err := clients.RunCommandStreaming(ctx, cmd, onLine)
 	if err != nil {
-		return "", handleCommandError(ctx, err, "Codex")
+		return "", handleCommandError(ctx, err, "Codex", timeout)
 	}
 
 	log.Info("Codex command completed successfully, outputLength: %d", len(result))
@@ -83,13 +86,13 @@ func (c *CodexClient) ContinueSession(threadID, prompt string, options *clients.
 
 // handleCommandError converts a clients.CommandError to a core.ErrClaudeCommandErr,
 // including timeout detection via context deadline.
-func handleCommandError(ctx context.Context, err error, agentName string) error {
+func handleCommandError(ctx context.Context, err error, agentName string, timeout time.Duration) error {
 	var cmdErr *clients.CommandError
 	if errors.As(err, &cmdErr) {
 		if ctx.Err() == context.DeadlineExceeded {
-			log.Error("⏰ %s session timed out after %s", agentName, clients.DefaultSessionTimeout)
+			log.Error("⏰ %s session timed out after %s", agentName, timeout)
 			return &core.ErrClaudeCommandErr{
-				Err:    fmt.Errorf("session timed out after %s: %w", clients.DefaultSessionTimeout, cmdErr.Err),
+				Err:    fmt.Errorf("session timed out after %s: %w", timeout, cmdErr.Err),
 				Output: cmdErr.Output,
 			}
 		}

--- a/clients/cursor/cursor.go
+++ b/clients/cursor/cursor.go
@@ -46,18 +46,19 @@ func (c *CursorClient) StartNewSession(prompt string, options *clients.CursorOpt
 	log.Info("Starting new Cursor session with prompt: %s", finalPrompt)
 	log.Info("Command arguments: %v", args)
 
-	ctx, cancel := context.WithTimeout(context.Background(), clients.DefaultSessionTimeout)
+	timeout := clients.SessionTimeout()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	cmd := clients.BuildAgentCommandWithContext(ctx, "cursor-agent", args...)
 
-	log.Info("Running Cursor command (timeout: %s)", clients.DefaultSessionTimeout)
+	log.Info("Running Cursor command (timeout: %s)", timeout)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
-			log.Error("⏰ Cursor session timed out after %s", clients.DefaultSessionTimeout)
+			log.Error("⏰ Cursor session timed out after %s", timeout)
 			return "", &core.ErrClaudeCommandErr{
-				Err:    fmt.Errorf("session timed out after %s: %w", clients.DefaultSessionTimeout, err),
+				Err:    fmt.Errorf("session timed out after %s: %w", timeout, err),
 				Output: string(output),
 			}
 		}
@@ -91,18 +92,19 @@ func (c *CursorClient) ContinueSession(sessionID, prompt string, options *client
 	log.Info("Executing Cursor command with sessionID: %s, prompt: %s", sessionID, prompt)
 	log.Info("Command arguments: %v", args)
 
-	ctx, cancel := context.WithTimeout(context.Background(), clients.DefaultSessionTimeout)
+	timeout := clients.SessionTimeout()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	cmd := clients.BuildAgentCommandWithContext(ctx, "cursor-agent", args...)
 
-	log.Info("Running Cursor command (timeout: %s)", clients.DefaultSessionTimeout)
+	log.Info("Running Cursor command (timeout: %s)", timeout)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
-			log.Error("⏰ Cursor session timed out after %s", clients.DefaultSessionTimeout)
+			log.Error("⏰ Cursor session timed out after %s", timeout)
 			return "", &core.ErrClaudeCommandErr{
-				Err:    fmt.Errorf("session timed out after %s: %w", clients.DefaultSessionTimeout, err),
+				Err:    fmt.Errorf("session timed out after %s: %w", timeout, err),
 				Output: string(output),
 			}
 		}

--- a/clients/opencode/opencode.go
+++ b/clients/opencode/opencode.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"time"
 
 	"nairid/clients"
 	"nairid/core"
@@ -39,15 +40,16 @@ func (c *OpenCodeClient) StartNewSession(prompt string, options *clients.OpenCod
 	log.Info("Starting new OpenCode session with prompt: %s", prompt)
 	log.Info("Command arguments: %v", args)
 
-	ctx, cancel := context.WithTimeout(context.Background(), clients.DefaultSessionTimeout)
+	timeout := clients.SessionTimeout()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	cmd := buildCommand(ctx, options, args)
 
-	log.Info("Running OpenCode command (timeout: %s)", clients.DefaultSessionTimeout)
+	log.Info("Running OpenCode command (timeout: %s)", timeout)
 	result, err := clients.RunCommandStreaming(ctx, cmd, onLine)
 	if err != nil {
-		return "", handleCommandError(ctx, err, "OpenCode")
+		return "", handleCommandError(ctx, err, "OpenCode", timeout)
 	}
 
 	log.Info("OpenCode command completed successfully, outputLength: %d", len(result))
@@ -76,15 +78,16 @@ func (c *OpenCodeClient) ContinueSession(sessionID, prompt string, options *clie
 	log.Info("Executing OpenCode command with sessionID: %s, prompt: %s", sessionID, prompt)
 	log.Info("Command arguments: %v", args)
 
-	ctx, cancel := context.WithTimeout(context.Background(), clients.DefaultSessionTimeout)
+	timeout := clients.SessionTimeout()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	cmd := buildCommand(ctx, options, args)
 
-	log.Info("Running OpenCode command (timeout: %s)", clients.DefaultSessionTimeout)
+	log.Info("Running OpenCode command (timeout: %s)", timeout)
 	result, err := clients.RunCommandStreaming(ctx, cmd, onLine)
 	if err != nil {
-		return "", handleCommandError(ctx, err, "OpenCode")
+		return "", handleCommandError(ctx, err, "OpenCode", timeout)
 	}
 
 	log.Info("OpenCode command completed successfully, outputLength: %d", len(result))
@@ -94,13 +97,13 @@ func (c *OpenCodeClient) ContinueSession(sessionID, prompt string, options *clie
 
 // handleCommandError converts a clients.CommandError to a core.ErrClaudeCommandErr,
 // including timeout detection via context deadline.
-func handleCommandError(ctx context.Context, err error, agentName string) error {
+func handleCommandError(ctx context.Context, err error, agentName string, timeout time.Duration) error {
 	var cmdErr *clients.CommandError
 	if errors.As(err, &cmdErr) {
 		if ctx.Err() == context.DeadlineExceeded {
-			log.Error("⏰ %s session timed out after %s", agentName, clients.DefaultSessionTimeout)
+			log.Error("⏰ %s session timed out after %s", agentName, timeout)
 			return &core.ErrClaudeCommandErr{
-				Err:    fmt.Errorf("session timed out after %s: %w", clients.DefaultSessionTimeout, cmdErr.Err),
+				Err:    fmt.Errorf("session timed out after %s: %w", timeout, cmdErr.Err),
 				Output: cmdErr.Output,
 			}
 		}

--- a/clients/process.go
+++ b/clients/process.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -16,22 +17,56 @@ import (
 // child processes keep the stdout pipe open.
 const WaitDelayAfterKill = 10 * time.Second
 
-// DefaultSessionTimeout is the maximum duration an agent CLI session can run
-// before being killed. This prevents hung processes from blocking the worker pool.
+// DefaultSessionTimeout is the fallback maximum duration an agent CLI session
+// can run before being killed. Prefer SessionTimeout() at runtime, which
+// honours the NAIRI_MAX_SESSION_MS env var override.
 const DefaultSessionTimeout = 1 * time.Hour
 
 // BlockedEnvVars lists environment variables that should never be passed to agent processes.
-// These contain sensitive credentials that agents should not have access to.
+// These contain sensitive credentials or nairid-internal config that agents should not see.
 var BlockedEnvVars = map[string]bool{
-	"NAIRI_API_KEY":      true,
-	"NAIRI_WS_API_URL":   true,
-	"EKSEC_API_KEY":      true, // Legacy env var
-	"EKSEC_WS_API_URL":   true, // Legacy env var
-	"CCAGENT_API_KEY":    true, // Legacy env var
-	"CCAGENT_WS_API_URL": true, // Legacy env var
-	"AGENT_EXEC_USER":    true,
-	"AGENT_HTTP_PROXY":   true, // This is for nairid to read, not for agents
-	"AGENT_MCP_PROXY":    true, // This is for nairid to read, not for agents
+	"NAIRI_API_KEY":        true,
+	"NAIRI_WS_API_URL":     true,
+	"NAIRI_MAX_SESSION_MS": true, // nairid-only config (CLI session timeout)
+	"EKSEC_API_KEY":        true, // Legacy env var
+	"EKSEC_WS_API_URL":     true, // Legacy env var
+	"EKSEC_MAX_SESSION_MS": true, // Legacy env var
+	"CCAGENT_API_KEY":      true, // Legacy env var
+	"CCAGENT_WS_API_URL":   true, // Legacy env var
+	"AGENT_EXEC_USER":      true,
+	"AGENT_HTTP_PROXY":     true, // This is for nairid to read, not for agents
+	"AGENT_MCP_PROXY":      true, // This is for nairid to read, not for agents
+}
+
+// SessionTimeout returns the per-CLI-session timeout used to bound a single
+// agent invocation (claude, codex, opencode, cursor).
+//
+// Resolution order:
+//  1. NAIRI_MAX_SESSION_MS — integer number of milliseconds (must be > 0)
+//  2. EKSEC_MAX_SESSION_MS — legacy fallback, same format
+//  3. DefaultSessionTimeout (1 hour) when neither is set or the value is invalid
+//
+// Operators who need long-running single-turn sessions can bump this without
+// recompiling nairid. The value is read on every call so a deployment can pick
+// up changes by restarting the daemon.
+func SessionTimeout() time.Duration {
+	raw := os.Getenv("NAIRI_MAX_SESSION_MS")
+	source := "NAIRI_MAX_SESSION_MS"
+	if raw == "" {
+		raw = os.Getenv("EKSEC_MAX_SESSION_MS")
+		source = "EKSEC_MAX_SESSION_MS"
+	}
+	if raw == "" {
+		return DefaultSessionTimeout
+	}
+
+	ms, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || ms <= 0 {
+		log.Printf("[SessionTimeout] invalid %s=%q, falling back to default %s", source, raw, DefaultSessionTimeout)
+		return DefaultSessionTimeout
+	}
+
+	return time.Duration(ms) * time.Millisecond
 }
 
 // AgentExecUser returns the configured user for running agent processes.

--- a/clients/process_test.go
+++ b/clients/process_test.go
@@ -80,6 +80,33 @@ func TestFilterEnvForAgent_LegacyEksecVars(t *testing.T) {
 	}
 }
 
+func TestFilterEnvForAgent_SessionTimeoutVars(t *testing.T) {
+	// NAIRI_MAX_SESSION_MS and EKSEC_MAX_SESSION_MS are nairid-internal config
+	// and must not leak into agent subprocess environments.
+	env := []string{
+		"PATH=/usr/bin",
+		"NAIRI_MAX_SESSION_MS=3600000",
+		"EKSEC_MAX_SESSION_MS=1800000",
+		"HOME=/home/user",
+	}
+
+	filtered := FilterEnvForAgent(env)
+
+	for _, e := range filtered {
+		if strings.HasPrefix(e, "NAIRI_MAX_SESSION_MS=") {
+			t.Errorf("NAIRI_MAX_SESSION_MS should be filtered out, but found: %s", e)
+		}
+		if strings.HasPrefix(e, "EKSEC_MAX_SESSION_MS=") {
+			t.Errorf("EKSEC_MAX_SESSION_MS should be filtered out, but found: %s", e)
+		}
+	}
+
+	// 4 original - 2 blocked = 2 remaining
+	if len(filtered) != 2 {
+		t.Errorf("Expected 2 filtered vars, got %d", len(filtered))
+	}
+}
+
 func TestFilterEnvForAgent_EmptyEnv(t *testing.T) {
 	filtered := FilterEnvForAgent([]string{})
 	if len(filtered) != 0 {
@@ -671,5 +698,51 @@ func TestProcessGroupKill_KillsChildProcesses(t *testing.T) {
 	if err == nil {
 		_ = syscall.Kill(-pgid, syscall.SIGKILL)
 		t.Error("process group should be dead after context cancellation, but it's still alive")
+	}
+}
+
+func TestSessionTimeout(t *testing.T) {
+	// Snapshot and restore both env vars around every subtest.
+	origNairi := os.Getenv("NAIRI_MAX_SESSION_MS")
+	origEksec := os.Getenv("EKSEC_MAX_SESSION_MS")
+	defer func() {
+		_ = os.Setenv("NAIRI_MAX_SESSION_MS", origNairi)
+		_ = os.Setenv("EKSEC_MAX_SESSION_MS", origEksec)
+	}()
+
+	tests := []struct {
+		name     string
+		nairi    string // value to set; empty means unset
+		eksec    string
+		expected time.Duration
+	}{
+		{"unset falls back to default", "", "", DefaultSessionTimeout},
+		{"NAIRI_MAX_SESSION_MS honored", "7200000", "", 2 * time.Hour},
+		{"EKSEC_MAX_SESSION_MS honored as legacy", "", "1800000", 30 * time.Minute},
+		{"NAIRI takes precedence over EKSEC", "10800000", "1800000", 3 * time.Hour},
+		{"invalid value falls back to default", "not-a-number", "", DefaultSessionTimeout},
+		{"zero falls back to default", "0", "", DefaultSessionTimeout},
+		{"negative falls back to default", "-1000", "", DefaultSessionTimeout},
+		{"small value (1 second) accepted", "1000", "", 1 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.nairi == "" {
+				_ = os.Unsetenv("NAIRI_MAX_SESSION_MS")
+			} else {
+				_ = os.Setenv("NAIRI_MAX_SESSION_MS", tt.nairi)
+			}
+			if tt.eksec == "" {
+				_ = os.Unsetenv("EKSEC_MAX_SESSION_MS")
+			} else {
+				_ = os.Setenv("EKSEC_MAX_SESSION_MS", tt.eksec)
+			}
+
+			got := SessionTimeout()
+			if got != tt.expected {
+				t.Errorf("SessionTimeout() = %s, want %s", got, tt.expected)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Replaces the hardcoded 1-hour `DefaultSessionTimeout` with a `SessionTimeout()` accessor that reads `NAIRI_MAX_SESSION_MS` (with `EKSEC_MAX_SESSION_MS` accepted as a legacy fallback) as an integer number of milliseconds.
- All four CLI client packages (`claude`, `codex`, `opencode`, `cursor`) now read the value once per `StartNewSession` / `ContinueSession` call and reuse it for both the context deadline and the timeout reported in error messages and log lines.
- Adds `NAIRI_MAX_SESSION_MS` and `EKSEC_MAX_SESSION_MS` to `BlockedEnvVars` so nairid's internal config doesn't leak into agent subprocesses.
- Invalid or non-positive values fall back to the 1-hour default and emit a warning log.
- README documents the new env var under a new "Optional Environment Variables" section.

## Why

The hardcoded 60-minute cap means any single agent turn (plan → implement → test in one run) gets killed at the 1-hour mark, regardless of how the daemon is deployed. Operators who want longer single-run sessions previously had to rebuild nairid. With this change they can bump the timeout via the systemd unit or container env without a release.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` — full suite passes
- [x] New \`TestSessionTimeout\` covers: unset, NAIRI honored, EKSEC honored, NAIRI precedence over EKSEC, invalid string, zero, negative, small positive value
- [x] New \`TestFilterEnvForAgent_SessionTimeoutVars\` verifies the new vars are stripped from agent env
- [ ] After deploy, set \`NAIRI_MAX_SESSION_MS=10800000\` (3h) on a test container, run a >1h single-turn task, confirm it runs to completion instead of being killed at 1h

🤖 Generated with [Claude Code](https://claude.com/claude-code)