### PR TITLE
fix(git): redact inline credentials from remote-URL logs

### DIFF
--- a/clients/git.go
+++ b/clients/git.go
@@ -711,7 +711,7 @@ func (g *GitClient) getRawRemoteURL() (string, error) {
 	}
 
 	rawRemoteURL := strings.TrimSpace(string(output))
-	log.Info("✅ Raw remote URL: %s", rawRemoteURL)
+	log.Info("✅ Raw remote URL: %s", RedactURLCredentials(rawRemoteURL))
 	log.Info("📋 Completed successfully - got raw remote URL")
 	return rawRemoteURL, nil
 }
@@ -1039,7 +1039,7 @@ func (g *GitClient) ValidateRemoteAccess() error {
 		return fmt.Errorf("failed to get remote URL: %w", err)
 	}
 
-	log.Info("🔍 Testing remote access for: %s", rawRemoteURL)
+	log.Info("🔍 Testing remote access for: %s", RedactURLCredentials(rawRemoteURL))
 
 	// Test remote access with git ls-remote HEAD with 10s timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -1058,7 +1058,7 @@ func (g *GitClient) ValidateRemoteAccess() error {
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Error("❌ Remote access validation failed: %v\nOutput: %s", err, string(output))
+		log.Error("❌ Remote access validation failed: %v\nOutput: %s", err, RedactURLCredentials(string(output)))
 		return g.parseRemoteAccessError(err, string(output), rawRemoteURL)
 	}
 
@@ -1069,6 +1069,8 @@ func (g *GitClient) ValidateRemoteAccess() error {
 
 func (g *GitClient) parseRemoteAccessError(err error, output, remoteURL string) error {
 	outputStr := strings.ToLower(output)
+	remoteURL = RedactURLCredentials(remoteURL)
+	output = RedactURLCredentials(output)
 
 	// Check for timeout first
 	if strings.Contains(err.Error(), "context deadline exceeded") {
@@ -1196,7 +1198,7 @@ func (g *GitClient) UpdateRemoteURLWithToken(token string) error {
 	}
 
 	currentURL := strings.TrimSpace(string(output))
-	log.Info("🔍 Current remote URL: %s", currentURL)
+	log.Info("🔍 Current remote URL: %s", RedactURLCredentials(currentURL))
 
 	// Extract repository details
 	repoDetails, err := g.extractRemoteRepoDetails(currentURL)
@@ -1206,7 +1208,7 @@ func (g *GitClient) UpdateRemoteURLWithToken(token string) error {
 	}
 
 	if repoDetails == nil {
-		log.Info("⚠️ Not a GitHub repository, skipping token update: %s", currentURL)
+		log.Info("⚠️ Not a GitHub repository, skipping token update: %s", RedactURLCredentials(currentURL))
 		return nil
 	}
 

--- a/clients/redact.go
+++ b/clients/redact.go
@@ -1,0 +1,14 @@
+package clients
+
+import "regexp"
+
+// urlCredentialsPattern matches a URL's userinfo (scheme://user[:password]@host).
+var urlCredentialsPattern = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.-]*://)[^/@\s]+@`)
+
+// RedactURLCredentials rewrites every scheme://user:pass@host occurrence to
+// scheme://***@host so remote URLs (e.g. https://x-access-token:<token>@github.com/...)
+// and command output that embeds them are safe to log. Input without embedded
+// credentials is returned unchanged.
+func RedactURLCredentials(s string) string {
+	return urlCredentialsPattern.ReplaceAllString(s, "${1}***@")
+}

--- a/clients/redact_test.go
+++ b/clients/redact_test.go
@@ -1,0 +1,50 @@
+package clients
+
+import "testing"
+
+func TestRedactURLCredentials(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "github pat in https remote",
+			in:   "https://x-access-token:github_pat_11ABCDEF_ghijkl@github.com/paypercut/agent-workspace.git",
+			want: "https://***@github.com/paypercut/agent-workspace.git",
+		},
+		{
+			name: "installation token in https remote",
+			in:   "https://x-access-token:ghs_secret123@github.com/o/r.git",
+			want: "https://***@github.com/o/r.git",
+		},
+		{
+			name: "plain https remote unchanged",
+			in:   "https://github.com/paypercut/agent-workspace.git",
+			want: "https://github.com/paypercut/agent-workspace.git",
+		},
+		{
+			name: "ssh scp-style remote unchanged",
+			in:   "git@github.com:paypercut/agent-workspace.git",
+			want: "git@github.com:paypercut/agent-workspace.git",
+		},
+		{
+			name: "credentials embedded in git error output",
+			in:   "fatal: unable to access 'https://x-access-token:ghs_secret@github.com/o/r.git/': The requested URL returned error: 403",
+			want: "fatal: unable to access 'https://***@github.com/o/r.git/': The requested URL returned error: 403",
+		},
+		{
+			name: "empty string",
+			in:   "",
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RedactURLCredentials(tc.in); got != tc.want {
+				t.Errorf("RedactURLCredentials(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/clients/redact_test.go
+++ b/clients/redact_test.go
@@ -10,28 +10,28 @@ func TestRedactURLCredentials(t *testing.T) {
 	}{
 		{
 			name: "github pat in https remote",
-			in:   "https://x-access-token:github_pat_11ABCDEF_ghijkl@github.com/paypercut/agent-workspace.git",
-			want: "https://***@github.com/paypercut/agent-workspace.git",
+			in:   "https://x-access-token:github_pat_11ABCDEF_ghijkl@github.com/owner/repo.git",
+			want: "https://***@github.com/owner/repo.git",
 		},
 		{
 			name: "installation token in https remote",
-			in:   "https://x-access-token:ghs_secret123@github.com/o/r.git",
-			want: "https://***@github.com/o/r.git",
+			in:   "https://x-access-token:ghs_secret123@github.com/owner/repo.git",
+			want: "https://***@github.com/owner/repo.git",
 		},
 		{
 			name: "plain https remote unchanged",
-			in:   "https://github.com/paypercut/agent-workspace.git",
-			want: "https://github.com/paypercut/agent-workspace.git",
+			in:   "https://github.com/owner/repo.git",
+			want: "https://github.com/owner/repo.git",
 		},
 		{
 			name: "ssh scp-style remote unchanged",
-			in:   "git@github.com:paypercut/agent-workspace.git",
-			want: "git@github.com:paypercut/agent-workspace.git",
+			in:   "git@github.com:owner/repo.git",
+			want: "git@github.com:owner/repo.git",
 		},
 		{
 			name: "credentials embedded in git error output",
-			in:   "fatal: unable to access 'https://x-access-token:ghs_secret@github.com/o/r.git/': The requested URL returned error: 403",
-			want: "fatal: unable to access 'https://***@github.com/o/r.git/': The requested URL returned error: 403",
+			in:   "fatal: unable to access 'https://x-access-token:ghs_secret@github.com/owner/repo.git/': The requested URL returned error: 403",
+			want: "fatal: unable to access 'https://***@github.com/owner/repo.git/': The requested URL returned error: 403",
 		},
 		{
 			name: "empty string",


### PR DESCRIPTION
The daemon logs the GitHub token in plaintext: git remotes carry it inline as `https://x-access-token:<token>@github.com/...`, and several git-client log lines print that URL verbatim.

Observed in a live daemon log:
```
✅ Raw remote URL: https://x-access-token:github_pat_1234...@github.com/acme/agent-workspace.git
🔍 Testing remote access for: https://x-access-token:github_pat_11B...@github.com/...
```

Changes:
- Add `RedactURLCredentials` (rewrites `scheme://user:pass@host` → `scheme://***@host`); leaves credential-free strings untouched.
- Apply it to the remote-URL log sites in `getRawRemoteURL`, `ValidateRemoteAccess`, and `UpdateRemoteURLWithToken`.
- Redact `remoteURL`/`output` in `parseRemoteAccessError`, which interpolates them into returned (later logged) errors.
- Unit tests covering PAT/installation-token URLs, plain HTTPS, SSH, embedded-in-output, and empty input.